### PR TITLE
Remove example as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tools/
 # Documentation output
 docs/_site
 docs/_site_pdf
+
+# Template repo
+example/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "example"]
-	path = example
-	url = git@github.com:pleonex/template-csharp

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Full automated build, test, stage and release pipeline for .NET projects based
 on Cake. Check also the
-[template repository](https://github.com/pleonex/template-csharp).
+[template repository](https://github.com/pleonex/template-csharp) to see the
+pipeline in action!
 
 | Release | Package |
 | ------- | ------- |


### PR DESCRIPTION
Remove the link to the template repository via submodule since it's difficult to keep it updated. Instead there is a link in the README.
