### PR TITLE
Fix missing define project when pushing artifacts

### DIFF
--- a/src/PleOps.Cake/targets.cake
+++ b/src/PleOps.Cake/targets.cake
@@ -11,6 +11,8 @@ Task("BuildTest")
     .IsDependentOn("Test");
 
 Task("Generate-ReleaseNotes")
+    .IsDependentOn("Define-Project") // Must be defined by the user
+    .IsDependentOn("Show-Info")
     .IsDependentOn("Create-GitHubDraftRelease")     // only preview builds
     .IsDependentOn("Export-GitHubReleaseNotes");    // only preview and stable builds
 
@@ -21,6 +23,8 @@ Task("Stage-Artifacts")
     .IsDependentOn("Pack-Apps");
 
 Task("Push-Artifacts")
+    .IsDependentOn("Define-Project") // Must be defined by the user
+    .IsDependentOn("Show-Info")
     .IsDependentOn("Push-NuGets")   // only preview and stable builds
     .IsDependentOn("Push-Apps")     // only stable builds
     .IsDependentOn("Push-Doc");     // only preview and stable builds


### PR DESCRIPTION
We weren't calling define project target when pushing artifacts so the feeds were the default always.