### PR TITLE
Push documentation to gh-pages

### DIFF
--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -36,7 +36,7 @@ Task("Build-Doc")
 
 Task("Push-Doc")
     .Description("Push the documentation to GitHub pages")
-    // .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType == BuildType.Stable)
+    .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
     .Does<BuildInfo>(info =>
 {
     // We don't depend on it so it can run as a different stage

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -2,8 +2,13 @@
 
 #tool nuget:?package=docfx.console&version=2.56.5
 #addin nuget:?package=Cake.DocFx&version=0.13.1
+#addin nuget:?package=Cake.Git&version=0.22.0
+
+using System.Linq;
+using LibGit2Sharp;
 
 Task("Build-Doc")
+    .Description("Build the documentation")
     .Does<BuildInfo>(info =>
 {
     if (!FileExists(info.DocFxFile)) {
@@ -31,8 +36,62 @@ Task("Build-Doc")
 
 Task("Push-Doc")
     .Description("Push the documentation to GitHub pages")
-    .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
+    // .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType == BuildType.Stable)
     .Does<BuildInfo>(info =>
 {
-    Warning("NOT IMPLEMENTED --> #14");
+    // We don't depend on it so it can run as a different stage
+    string docBuild = $"{info.ArtifactsDirectory}/_site";
+    if (!DirectoryExists(docBuild)) {
+        throw new Exception("Documentation is not build. Run 'Build-Doc' task first.");
+    }
+
+    // TODO: [#6] Implement multi-version documentation
+    string pushWorktreeName = "push-gh-pages";
+    string committerName = "PleOps.Cake Bot";
+    string committerEmail = "ci@pleops.cake";
+
+    using (Repository repo = new Repository(GitFindRootFromPath(".").FullPath)) {
+        bool ownTree = false;
+        Worktree tree = null;
+        if (repo.Worktrees.Any(w => w.Name == pushWorktreeName)) {
+            Information("Re-using worktree");
+            tree = repo.Worktrees[pushWorktreeName];
+        } else {
+            Information("Creating worktree");
+
+            // libgit2sharp does not clean the refs and it complains if you run it again later
+            string refPath = $"{repo.Info.Path}/refs/heads/{pushWorktreeName}";
+            if (FileExists(refPath)) {
+                Information("Deleting old ref");
+                DeleteFile(refPath);
+            }
+
+            CreateDirectory($"{info.ArtifactsDirectory}/tmp");
+            tree = repo.Worktrees.Add(
+                "gh-pages",
+                pushWorktreeName,
+                $"{info.ArtifactsDirectory}/tmp/gh-pages",
+                false); // no lock since it's not a portable media
+            ownTree = true;
+        }
+
+        Information($"Worktree at: {tree.WorktreeRepository.Info.WorkingDirectory} - Copying files");
+        CopyFiles($"{docBuild}/*", tree.WorktreeRepository.Info.WorkingDirectory);
+
+        Information("Staging and committing all");
+        Commands.Stage(tree.WorktreeRepository, "*");
+        tree.WorktreeRepository.Commit(
+            $"Documentation update for {info.Version}",
+            new Signature(committerName, committerEmail, DateTimeOffset.Now),
+            new Signature(committerName, committerEmail, DateTimeOffset.Now),
+            new CommitOptions());
+
+        Information("Pushing");
+        tree.WorktreeRepository.Network.Push(tree.WorktreeRepository.Head);
+
+        if (ownTree) {
+            Information("Pruning worktree");
+            repo.Worktrees.Prune(tree);
+        }
+    }
 });

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -84,7 +84,7 @@ Task("Push-Doc")
 
             Information("Commit");
             tree.WorktreeRepository.Commit(
-                $"Documentation update for {info.Version}",
+                $":books: Documentation update for {info.Version}",
                 new Signature(committerName, committerEmail, DateTimeOffset.Now),
                 new Signature(committerName, committerEmail, DateTimeOffset.Now),
                 new CommitOptions());


### PR DESCRIPTION
Push the documentation to GitHub Pages on stable and preview releases.

This closes #14.