### PR TITLE
Trigger workflow on GitHub release publication and add badges

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,6 +9,9 @@ on:
     branches: [ develop ]
     # Stable
     tags: [ "v*" ]
+  release:
+    types:
+      - published
 
 env:
   NET_SDK: '5.0.101'

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ on Cake. Check also the
 [template repository](https://github.com/pleonex/template-csharp) to see the
 pipeline in action!
 
-| Release | Package |
-| ------- | ------- |
-| Stable  | TBD     |
-| Preview | TBD     |
+<!-- prettier-ignore -->
+| Release | Provider              | Package                                                          |
+| ------- | --------------------- | ---------------------------------------------------------------- |
+| Stable  | nuget.org             | ![Stable](https://img.shields.io/nuget/v/PleOps.Cake?style=flat) |
+| Preview | Azure public artifact | ![Preview](https://feeds.dev.azure.com/benito356/339c91a8-9d6c-4082-8b1a-93c2ae76b637/_apis/public/Packaging/Feeds/f434f007-6349-4876-9d16-e00ec2460ec0/Packages/ed658fe0-1126-4ed5-9488-601f02d8756b/Badge) |
 
 ## Requirements
 


### PR DESCRIPTION
It seems the tag push notification doesn't trigger on GitHub releases. Fixed by adding the release publication notification. Also add badges.