### PR TITLE
Implement renaming and closing milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ on Cake. Check also the
 pipeline in action!
 
 <!-- prettier-ignore -->
-| Release | Provider              | Package                                                          |
-| ------- | --------------------- | ---------------------------------------------------------------- |
-| Stable  | nuget.org             | ![Stable](https://img.shields.io/nuget/v/PleOps.Cake?style=flat) |
-| Preview | Azure public artifact | ![Preview](https://feeds.dev.azure.com/benito356/339c91a8-9d6c-4082-8b1a-93c2ae76b637/_apis/public/Packaging/Feeds/f434f007-6349-4876-9d16-e00ec2460ec0/Packages/ed658fe0-1126-4ed5-9488-601f02d8756b/Badge) |
+| Release | Package                                                           |
+| ------- | ----------------------------------------------------------------- |
+| Stable  | [![Nuget](https://img.shields.io/nuget/v/PleOps.Cake?label=nuget.org&logo=nuget)](https://www.nuget.org/packages/PleOps.Cake) |
+| Preview | [Azure Artifacts](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps) |
 
 ## Requirements
 

--- a/src/PleOps.Cake/PleOps.Cake.csproj
+++ b/src/PleOps.Cake/PleOps.Cake.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Description>Cake utilities to implement a DevFlow pipeline in .NET.</Description>
+        <Description>Cake tasks for trunk-development workflows with .NET projects.</Description>
 
         <!-- No .NET code to include in the nuget. -->
         <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/PleOps.Cake/releasenotes.cake
+++ b/src/PleOps.Cake/releasenotes.cake
@@ -1,5 +1,8 @@
 #load "setup.cake"
 #tool "nuget:?package=gitreleasemanager&version=0.11.0"
+#addin nuget:?package=Octokit&version=0.48.0
+
+using System.Linq;
 
 Task("Create-GitHubDraftRelease")
     .Description("Create a GitHub draft release with release notes")
@@ -49,3 +52,77 @@ Task("Export-GitHubReleaseNotes")
         info.RepositoryName,
         info.ChangelogFile);
 });
+
+Task("Close-GitHubMilestone")
+    .Description("Rename vNext milestone and close it. Rename and re-create Future milestone")
+    .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType == BuildType.Stable)
+    .WithCriteria<BuildInfo>((ctxt, info) => !string.IsNullOrEmpty(info.GitHubToken))
+    .Does<BuildInfo>(info =>
+{
+    string versionName = $"v{info.Version}";
+
+    var client = new Octokit.GitHubClient(new Octokit.ProductHeaderValue("PleOps.Cake"));
+    client.Credentials = new Octokit.Credentials(info.GitHubToken);
+
+    var milestoneClient = client.Issue.Milestone;
+    var milestones = milestoneClient.GetAllForRepository(
+        info.RepositoryOwner,
+        info.RepositoryName).Result;
+    if (milestones.Any(m => m.Title == versionName)) {
+        Information("Found already a milestone for the current version. Skipping.");
+        return;
+    }
+
+    var result = RenameMilestone(info, milestoneClient, milestones, info.WorkMilestone, versionName);
+    if (result) {
+        Information("Closing work milestone");
+        GitReleaseManagerClose(
+            info.GitHubToken,
+            info.RepositoryOwner,
+            info.RepositoryName,
+            versionName);
+
+        result = RenameMilestone(info, milestoneClient, milestones, info.FutureMilestone, info.WorkMilestone);
+        if (result) {
+            CreateMilestone(info, milestoneClient, info.FutureMilestone);
+        }
+    }
+});
+
+bool RenameMilestone(BuildInfo info, Octokit.IMilestonesClient client, IEnumerable<Octokit.Milestone> milestones, string currentName, string newName)
+{
+    var milestone = milestones.FirstOrDefault(m => m.Title == currentName);
+    if (milestone == null) {
+        Information($"Can't find milestone '{currentName}'. Skipping.");
+        return false;
+    }
+
+    if (milestone.State != Octokit.ItemState.Open) {
+        Information($"Milestone '{currentName} is not open: '{milestone.State}'. Skipping.");
+        return false;
+    }
+
+    Information($"Renaming milestone '{currentName}' to '{newName}'");
+    var renameRequest = new Octokit.MilestoneUpdate {
+        Title = newName,
+        Description = milestone.Description,
+        State = milestone.State.Value,
+        DueOn = milestone.DueOn,
+    };
+    client.Update(
+        info.RepositoryOwner,
+        info.RepositoryName,
+        milestone.Number,
+        renameRequest).Wait();
+    return true;
+}
+
+void CreateMilestone(BuildInfo info, Octokit.IMilestonesClient client, string name)
+{
+    Information($"Creating milestone '{name}'");
+    var request = new Octokit.NewMilestone(name);
+    client.Create(
+        info.RepositoryOwner,
+        info.RepositoryName,
+        request).Wait();
+}

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -46,6 +46,8 @@ public class BuildInfo
 
     public string WorkMilestone { get; set; }
 
+    public string FutureMilestone { get; set; }
+
     public string ChangelogNextFile { get; set; }
 
     public string ChangelogFile { get; set; }
@@ -128,6 +130,7 @@ Setup<BuildInfo>(context =>
         StableNuGetFeed = "https://api.nuget.org/v3/index.json",
         StableNuGetFeedToken = EnvironmentVariable("STABLE_NUGET_FEED_TOKEN"),
         WorkMilestone = "vNext",
+        FutureMilestone = "Future",
         ChangelogNextFile = Argument("changelog-next", "./CHANGELOG.NEXT.md"),
         ChangelogFile = Argument("changelog", "./CHANGELOG.md"),
         CoverageTarget = 100,

--- a/src/PleOps.Cake/targets.cake
+++ b/src/PleOps.Cake/targets.cake
@@ -27,4 +27,5 @@ Task("Push-Artifacts")
     .IsDependentOn("Show-Info")
     .IsDependentOn("Push-NuGets")   // only preview and stable builds
     .IsDependentOn("Push-Apps")     // only stable builds
-    .IsDependentOn("Push-Doc");     // only preview and stable builds
+    .IsDependentOn("Push-Doc")      // only preview and stable builds
+    .IsDependentOn("Close-GitHubMilestone");    // only stable builds


### PR DESCRIPTION
On stable releases do the milestone management automatically.

- Rename `vNext` to `v{version}`
- Close `v{version}` with GitReleaseManager so it could trigger auto-comment in issues
- Rename `Future` to `vNext`
- Re-create `Future`

Also improve package description and badges.