### PR TITLE
Fix development environment after Docker image upgrade

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VARIANT="3.1"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-${VARIANT}
+# TODO #35 Support Ubuntu 20.04
+FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0.148.1-3.1
 
 # Install .NET 5.0
 RUN apt-get update \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
         "hediet.vscode-drawio",
         "esbenp.prettier-vscode",
         "yzhang.markdown-all-in-one",
-        "davidanson.vscode-markdownlint"
+        "davidanson.vscode-markdownlint",
+        "eamodio.gitlens"
     ],
 
     "remoteUser": "vscode",

--- a/README.md
+++ b/README.md
@@ -35,4 +35,7 @@ The following target are available for build, test and release.
 
 ## Documentation
 
-Check the documentation for more information.
+Check the [documentation](https://www.pleonex.dev/PleOps.Cake/) for more
+information. For reference, this is the general build and release pipeline.
+
+![release diagram](./docs/guides/spec/release_automation.png)

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -27,7 +27,7 @@
           "exclude": [ "**/*.png", "**/*.drawio" ]
         },
         {
-          "files": ["README.md", "CONTRIBUTING.md"],
+          "files": ["CONTRIBUTING.md"],
           "src": "../"
         }
       ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,44 @@
----
-uid: README
----
+# .NET DevOps Pipeline
 
-[!include[README](../README.md)]
+![Build and release](https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=develop&event=push)
+
+Full automated build, test, stage and release pipeline for .NET projects based
+on Cake. Check also the
+[template repository](https://github.com/pleonex/template-csharp) to see the
+pipeline in action!
+
+<!-- prettier-ignore -->
+| Release | Package                                                           |
+| ------- | ----------------------------------------------------------------- |
+| Stable  | [![Nuget](https://img.shields.io/nuget/v/PleOps.Cake?label=nuget.org&logo=nuget)](https://www.nuget.org/packages/PleOps.Cake) |
+| Preview | [Azure Artifacts](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps) |
+
+## Requirements
+
+- .NET 5.0 SDK
+- .NET Core 3.1 runtime
+
+## Build system command
+
+The following target are available for build, test and release.
+
+- `BuildTest`: build the project and run its tests and quality assurance tools.
+
+- `Generate-ReleaseNotes`: generate a release notes and full changelog by
+  analyzing issues and PR of GitHub.
+
+- `Stage-Artifacts`: run `BuildTest`, generate the release notes, build the
+  documentation, pack the libraries in NuGet and stage the executables.
+
+- `Push-Artifacts`: push the libraries, applications and documentation to the
+  preview or stable feed.
+
+## Documentation
+
+Check the [Pipeline Workflow](./guides/spec/PipelineWorkflow.md) document to
+learn how the build system works. Also don't miss the
+[Project Setup](./guides/Project%20setup.md) to learn how to start using this
+build system.
+
+For reference, this is the general build and release pipeline:
+![release diagram](./guides/spec/release_automation.png)


### PR DESCRIPTION
Microsoft updated the docker image and moved to Ubuntu 20.04. This was breaking libgit2sharp. For now we revert back to Ubuntu 18.04 while #35 is implemented.

Also install GitLens plugins in VSCode and small improvement in readme and documentation.

This closes #36 