### PR TITLE
Upgrade to Cake 1.0-rc2 and bump dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,9 +23,9 @@
 
     "remoteUser": "vscode",
 
-    // Required for Podman (Docker alternative)
+    // PODMAN ONLY. You may need to remove this line for Docker.
     // SELinux issues: https://github.com/containers/podman/issues/3683
-    "runArgs": [ "--security-opt", "label=disable" ],
+    "runArgs": [ "--security-opt", "label=disable", "--userns=keep-id" ],
 
     // Podman issues: https://github.com/microsoft/vscode-remote-release/issues/3231
     "containerEnv": {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+### Description
+
+A clear and concise description of what the bug or feature is.
+
 ### Example
 
 Small example on how to use the new classes and methods.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-### Description
-
-A clear and concise description of what the bug or feature is.
-
 ### Example
 
 Small example on how to use the new classes and methods.

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -36,9 +36,7 @@ jobs:
           dotnet-version: '3.1.404'
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       - name: "Generate release notes"
         run: dotnet cake --target=Generate-ReleaseNotes --verbosity=diagnostic
@@ -90,9 +88,7 @@ jobs:
           dotnet-version: '3.1.404'
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       # Weird way to authenticate in Azure DevOps Artifacts
       # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.56.5
+#tool nuget:?package=docfx.console&version=2.56.6
 #addin nuget:?package=Cake.DocFx&version=0.13.1
 #addin nuget:?package=Cake.Git&version=0.22.0
 

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,6 +1,6 @@
 #module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
 #addin nuget:?package=Cake.Git&version=0.22.0
-#tool dotnet:?package=GitVersion.Tool&version=5.5.1
+#tool dotnet:?package=GitVersion.Tool&version=5.6.0
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;


### PR DESCRIPTION
### Description

Bump to latest Cake version: 1.0-rc2. Bump GitVersion and DocFX dependencies with small fixes.

Add missing Podman flag and remove unnecessary workflow step.