### PR TITLE
Support projects in sub-folders and other locations and improve porting doc

### DIFF
--- a/docs/guides/Project setup.md
+++ b/docs/guides/Project setup.md
@@ -1,10 +1,12 @@
 # Project setup
 
+## New setup
+
 Use the [project template](https://github.com/pleonex/template-csharp) to
 initialize a new repository, or adapt an existing one copying its file and
 structure. Then follow this checklist to adapt the template to your project.
 
-## Setup
+### Project files
 
 - [ ] Update README.md: title and description.
 - [ ] Update LICENSE: copyright author
@@ -15,14 +17,14 @@ structure. Then follow this checklist to adapt the template to your project.
 - [ ] Update the icons of the project at `docs/images/`.
 - [ ] Update the `.csproj` files with the correct dependencies.
 
-## Documentation
+### Documentation
 
 - [ ] Update the first steps doc at `docs/guides/First-Steps.md`.
 - [ ] Update `docs/docfx.json` with the path to the API project files.
 - [ ] Update `docs/global_metadata.json` with the properties of the project.
 - [ ] Update `docs/toc.yml` with the project URL.
 
-## Build and release workflows
+### Build and release workflows
 
 - [ ] Create the milestone `vNext`.
 - [ ] Update `launch.json` with the path of the console application (if any).
@@ -35,3 +37,68 @@ structure. Then follow this checklist to adapt the template to your project.
       the preview NuGet feed.
 - [ ] Add a new secret `STABLE_NUGET_FEED_TOKEN` with the API key for the stable
       NuGet feed.
+
+## Port existing project
+
+In general follow these steps to take and adapt the files from the
+[project template](https://github.com/pleonex/template-csharp).
+
+1. Copy the folder `.devcontainer` and starts VS Code. When asked, re-open the
+   folder inside the container. Congratulations, now you have a clean dev
+   environment.
+
+2. Compare the content of the example `README.md`, `LICENSE`,
+   `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md` files and make any
+   desired modifications.
+
+3. Copy and adapt the file `src/Directory.Build.props`. It defines the
+   information for the NuGet packages and _SourceLink_. Remove the redundant
+   information from your `.csproj`.
+
+4. Follow the format of `src/Directory.Packages.props` to migrate to
+   [_centralized NuGet packages_](https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions).
+   Add each of your dependencies as `PackageVersion` and remove the version in
+   each of your `.csproj`.
+
+   - Add a dependency with `coverlet.collector` if you want to have code
+     coverage in your test projects.
+
+5. Compare your `.csproj` with the example provider. They should look similar.
+   Remember to pack the icon in your public libraries and to define the
+   `RuntimeIdentifier` in applications.
+
+6. Copy and adapt `.editorconfig` to follow your project coding style
+   guidelines. This file also defines some ignore rules. Pay attention to the
+   end of the file where it ignores special rules for test projects, you may
+   need to adjust the glob expression.
+
+7. Copy `.config`, `Tests.runsettings`, `GitVersion.yml` and `build.cake`.
+   Update the `Define-Project` task to list your project names and the preview
+   and stable NuGet feeds.
+
+   - You should be able to restore the build tool with `dotnet tool restore` and
+     build and run the tests of your project with
+     `dotnet cake --target=BuildTest`.
+
+8. Copy, compare and adapt the DocFX configuration and TOC files. In the
+   `docs/dev/Changelog.md` file the full changelog will be written.
+
+9. Copy the workflow from `.github/workflows`. Adapt the value of
+   `PREVIEW_NUGET_FEED` and create the two required secrets:
+   `STABLE_NUGET_FEED_TOKEN` and `PREVIEW_NUGET_FEED_TOKEN`.
+
+10. Copy `GitReleaseManager.yaml` and adapt to your issue labels.
+
+11. Copy the GitHub templates for issues and pull requests:
+    `.github/ISSUE_TEMPLATE` and `PULL_REQUEST_TEMPLATE.md`.
+
+12. Copy the `.vscode` to have build and launch tasks for VS Code. Adapt the
+    path to launch your applications (if any).
+
+13. Make sure there is a `gh-pages` branch. You can create a new one with the
+    following commands:
+
+    ```sh
+    git checkout --orphan gh-pages
+    git commit --allow-empty ":sparkles: Initial doc branch"
+    ```

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -90,21 +90,24 @@ public class BuildInfo
     public void AddLibraryProjects(params string[] names)
     {
         foreach (var name in names) {
-            libraries.Add($"./src/{name}/{name}.csproj");
+            string path = System.IO.File.Exists(name) ? name : $"./src/{name}/{name}.csproj";
+            libraries.Add(path);
         }
     }
 
     public void AddApplicationProjects(params string[] names)
     {
         foreach (var name in names) {
-            consoles.Add($"./src/{name}/{name}.csproj");
+            string path = System.IO.File.Exists(name) ? name : $"./src/{name}/{name}.csproj";
+            consoles.Add(path);
         }
     }
 
     public void AddTestProjects(params string[] names)
     {
         foreach (var name in names) {
-            tests.Add($"./src/{name}/{name}.csproj");
+            string path = System.IO.File.Exists(name) ? name : $"./src/{name}/{name}.csproj";
+            tests.Add(path);
         }
     }
 }


### PR DESCRIPTION
### Description

Support specifing libraries, test and application projects in other paths and subpaths than the `./src` directory.
Also improve migration guidelines.

### Example

If the value given is an existing project file, then it uses that full value. If the value is not pointing to an existing file then it continues to search the file in `./src/{value}/{value}.csproj`.

```csharp
info.AddApplicationProjects("src/MyConsole/MyConsole.csproj");
info.AddTestProjects("MyTests");
```

This closes #7
