### PR TITLE
Support test setting file from other paths or missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# .NET DevOps Pipeline
-
-![Build and release](https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=develop&event=push)
+# PleOps.Cake pipeline [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://choosealicense.com/licenses/mit/) ![Build and release](https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=develop&event=push)
 
 Full automated build, test, stage and release pipeline for .NET projects based
 on Cake. Check also the
@@ -35,7 +33,34 @@ The following target are available for build, test and release.
 
 ## Documentation
 
+Feel free to ask any question in the
+[project Discussion site!](https://github.com/pleonex/PleOps.Cake/discussions)
+
 Check the [documentation](https://www.pleonex.dev/PleOps.Cake/) for more
 information. For reference, this is the general build and release pipeline.
 
 ![release diagram](./docs/guides/spec/release_automation.png)
+
+## Build
+
+The project requires to build .NET 5.0 SDK and .NET Core 3.1 runtime. If you
+open the project with VS Code and you did install the
+[VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
+extension, you can have an already pre-configured development environment with
+Docker or Podman.
+
+To build, test and generate artifacts run:
+
+```sh
+# Only required the first time
+dotnet tool restore
+
+# Default target is Stage-Artifacts
+dotnet cake
+```
+
+To just build and test quickly, run:
+
+```sh
+dotnet cake --target=BuildTest
+```

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -138,7 +138,7 @@ Setup<BuildInfo>(context =>
         ChangelogFile = Argument("changelog", "./CHANGELOG.md"),
         CoverageTarget = 100,
         DocFxFile = "./docs/docfx.json",
-        RunSettingsFile = "./Tests.runsettings",
+        RunSettingsFile = FindTestSettings(),
     };
 
     SetVersion(info);
@@ -200,6 +200,23 @@ void FindRepoInfo(BuildInfo info)
     if (sshStartPath != -1) {
         info.RepositoryOwner = info.RepositoryOwner.Substring(sshStartPath + 1);
     }
+}
+
+string FindTestSettings()
+{
+    var possiblePaths = new string[] {
+        "./Tests.runsettings",
+        "./src/Tests.runsettings",
+    };
+
+    foreach (string path in possiblePaths) {
+        if (FileExists(path)) {
+            return path;
+        }
+    }
+
+    Verbose("Couldn't find the test setting file");
+    return string.Empty;
 }
 
 Task("Show-Info")


### PR DESCRIPTION
### Description

The test setting file `Tests.runtsettings` now it can be in other directories than the top-level. By default, the system will search in the top-level (backward compatibility) and in the `src` directory. Other places are possible by defining the variable in the `Define-Project` task.

The output test path is defined from the location of the test setting file. If there isn't a test setting file, then it will default to `<artifacts_directory>/test_results`. Also, the test task won't fail if the file doesn't exist.

The code coverage exit is now handled and won't fail if `WarningsAsErrors` is disabled.

### Example

In the template repository the file has been moved into the `src` directory.