### PR TITLE
Upgrade Cake and dependencies to support Ubuntu 20.04

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0002",
+      "version": "1.1.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,9 @@
-# TODO #35 Support Ubuntu 20.04
-FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0.148.1-3.1
-
-# Install .NET 5.0
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y apt-transport-https \
-    && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y dotnet-sdk-5.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:5.0
 
 # Install Mono (soon won't be necessary (.NET 6?))
 RUN apt install gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dev (Ubuntu - .NET 5, 3.1 and Mono)",
+    "name": "Dev (Ubuntu - .NET 5 and Mono)",
     "build": {
         "dockerfile": "Dockerfile",
     },

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.101'
+  NET_SDK: '5.0.201'
 
 jobs:
   build:
@@ -30,10 +30,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.404'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -82,10 +78,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.404'
 
       - name: "Install build tools"
         run: dotnet tool restore

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ pipeline in action!
 
 ## Requirements
 
-- .NET 5.0 SDK
+- .NET 5 SDK
 - .NET Core 3.1 runtime
+- [Linux and MacOS only] Mono 6
 
 ## Build system command
 
@@ -43,8 +44,8 @@ information. For reference, this is the general build and release pipeline.
 
 ## Build
 
-The project requires to build .NET 5.0 SDK and .NET Core 3.1 runtime. If you
-open the project with VS Code and you did install the
+The project requires to build .NET 5 SDK (Linux and MacOS require also Mono). If
+you open the project with VS Code and you did install the
 [VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
 extension, you can have an already pre-configured development environment with
 Docker or Podman.

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,8 +1,8 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.56.6
+#tool nuget:?package=docfx.console&version=2.56.7
 #addin nuget:?package=Cake.DocFx&version=0.13.1
-#addin nuget:?package=Cake.Git&version=0.22.0
+#addin nuget:?package=Cake.Git&version=1.0.1
 
 using System.Linq;
 using LibGit2Sharp;

--- a/src/PleOps.Cake/releasenotes.cake
+++ b/src/PleOps.Cake/releasenotes.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 #tool "nuget:?package=gitreleasemanager&version=0.11.0"
-#addin nuget:?package=Octokit&version=0.48.0
+#addin nuget:?package=Octokit&version=0.50.0
 
 using System.Linq;
 

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,6 +1,5 @@
-#module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
-#addin nuget:?package=Cake.Git&version=0.22.0
-#tool dotnet:?package=GitVersion.Tool&version=5.6.0
+#addin nuget:?package=Cake.Git&version=1.0.1
+#tool dotnet:?package=GitVersion.Tool&version=5.6.6
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;


### PR DESCRIPTION
### Description

Update the project Cake dependencies and Cake so it can run under Ubuntu 20.04 and higher, including the new Docker images for .NET and Azure DevOps/GitHub.

This closes #35