### PR TITLE
Update DocFX to 2.58 to fix build issues on Windows

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.201'
+  NET_SDK: '5.0.301'
 
 jobs:
   build:

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.57.2
+#tool nuget:?package=docfx.console&version=2.58.0
 #addin nuget:?package=Cake.DocFx&version=1.0.0
 #addin nuget:?package=Cake.Git&version=1.0.1
 


### PR DESCRIPTION
### Description

Update DocFX to version 2.58 to fix CI build issues with Windows when using latest VS.
Also update the .NET SDK version of the CI.