### PR TITLE
Fix potential issue pushing doc branch

### DIFF
--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -68,7 +68,7 @@ Task("Push-Doc")
 
             CreateDirectory($"{info.ArtifactsDirectory}/tmp");
             tree = repo.Worktrees.Add(
-                "gh-pages",
+                "origin/gh-pages",
                 pushWorktreeName,
                 $"{info.ArtifactsDirectory}/tmp/gh-pages",
                 false); // no lock since it's not a portable media


### PR DESCRIPTION
### Description

For some reason the CI started to fail saying the `gh-pages` is not a valid reference. This PR aims to fix it by using the remote name syntax.
