### PR TITLE
Revert GitVersion upgrade

### DIFF
--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,5 +1,8 @@
 #addin nuget:?package=Cake.Git&version=1.0.1
-#tool dotnet:?package=GitVersion.Tool&version=5.6.10
+
+// For some reason version 5.6.10 fails with GitWorktree pushing the docs
+#tool dotnet:?package=GitVersion.Tool&version=5.6.6
+
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;


### PR DESCRIPTION
### Description

__I think__ that the latest version of GitVersion is causing issues to push the docs via git worktree. Revert to the known working version.
