### PR TITLE
Downgrade .NET SDK to fix builds

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -56,7 +56,7 @@ jobs:
   # Stable release on version tag push only
   push_artifacts:
     name: "Push artifacts"
-    # if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
     needs: "build"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -56,7 +56,7 @@ jobs:
   # Stable release on version tag push only
   push_artifacts:
     name: "Push artifacts"
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
+    # if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
     needs: "build"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.301'
+  NET_SDK: '5.0.201'
 
 jobs:
   build:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.201'
+  NET_SDK: '5.0.300'
 
 jobs:
   build:

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.58.0
+#tool nuget:?package=docfx.console&version=2.56.7
 #addin nuget:?package=Cake.DocFx&version=1.0.0
 #addin nuget:?package=Cake.Git&version=1.0.1
 
@@ -36,7 +36,7 @@ Task("Build-Doc")
 
 Task("Push-Doc")
     .Description("Push the documentation to GitHub pages")
-    .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
+    // .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
     .Does<BuildInfo>(info =>
 {
     // We don't depend on it so it can run as a different stage

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -36,7 +36,7 @@ Task("Build-Doc")
 
 Task("Push-Doc")
     .Description("Push the documentation to GitHub pages")
-    // .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
+    .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
     .Does<BuildInfo>(info =>
 {
     // We don't depend on it so it can run as a different stage

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.56.7
+#tool nuget:?package=docfx.console&version=2.58.0
 #addin nuget:?package=Cake.DocFx&version=1.0.0
 #addin nuget:?package=Cake.Git&version=1.0.1
 

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,6 +1,5 @@
 #addin nuget:?package=Cake.Git&version=1.0.1
 #tool dotnet:?package=GitVersion.Tool&version=5.6.10
-
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,7 +1,5 @@
 #addin nuget:?package=Cake.Git&version=1.0.1
-
-// For some reason version 5.6.10 fails with GitWorktree pushing the docs
-#tool dotnet:?package=GitVersion.Tool&version=5.6.6
+#tool dotnet:?package=GitVersion.Tool&version=5.6.10
 
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
### Description

For some reason .NET 5.0.301 is causing issues with git in the GitHub Action CI. Downgrading to 300 seems to fix.