### PR TITLE
Add directory separator to publish directory and small fix doc

### DIFF
--- a/docs/guides/Project setup.md
+++ b/docs/guides/Project setup.md
@@ -96,9 +96,11 @@ In general follow these steps to take and adapt the files from the
     path to launch your applications (if any).
 
 13. Make sure there is a `gh-pages` branch. You can create a new one with the
-    following commands:
+    following commands (**make sure you don't have pending changes to commit**):
 
     ```sh
     git checkout --orphan gh-pages
-    git commit --allow-empty ":sparkles: Initial doc branch"
+    git reset * .*
+    git commit --allow-empty -m ":sparkles: Initial doc branch"
+    git checkout -b main
     ```

--- a/src/PleOps.Cake/build.cake
+++ b/src/PleOps.Cake/build.cake
@@ -69,7 +69,7 @@ Task("Pack-Apps")
             // it builds only for the current runtime, we need to rebuild.
             // This makes debugger easier as the path is the same between arch.
             // We don't force self-contained, we let developer choose in the .csproj
-            string outputDir = $"{info.ArtifactsDirectory}/tmp/{runtime}/{projectName}";
+            string outputDir = $"{info.ArtifactsDirectory}/tmp/{runtime}/{projectName}/";
             var publishSettings = new DotNetCorePublishSettings {
                 Configuration = info.Configuration,
                 OutputDirectory = outputDir,


### PR DESCRIPTION
### Description

Add the directory separator to the publish directory. This is required to publish applications to Mac with the Eto.Forms UI framework, as they concatenate paths. The default publish directory already provides it too.

Also fix an small issue in the docs.