### PR TITLE
Update dependencies to support .NET 6

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:5.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 
-# Install Mono (soon won't be necessary (.NET 6?))
-RUN apt install -y gnupg ca-certificates \
+# Install Mono (for DocFX)
+RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
-    "name": "Dev (Ubuntu - .NET 5 and Mono)",
+    "name": "Dev (.NET 6 and Mono)",
     "build": {
         "dockerfile": "Dockerfile",
-    },
-
-    "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
     },
 
     "extensions": [

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.402'
+  NET_SDK: '6.0.100'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ pipeline in action!
 
 ## Requirements
 
-- .NET 5 SDK
-- .NET Core 3.1 runtime
-- [Linux and MacOS only] Mono 6
+- .NET 6.0 SDK
+- [Linux and MacOS only] Mono 6 (for DocFX)
 
 ## Build system command
 
@@ -44,8 +43,8 @@ information. For reference, this is the general build and release pipeline.
 
 ## Build
 
-The project requires to build .NET 5 SDK (Linux and MacOS require also Mono). If
-you open the project with VS Code and you did install the
+The project requires to build .NET 6.0 SDK (Linux and MacOS require also Mono).
+If you open the project with VS Code and you did install the
 [VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
 extension, you can have an already pre-configured development environment with
 Docker or Podman.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,8 @@ pipeline in action!
 
 ## Requirements
 
-- .NET 5.0 SDK
-- .NET Core 3.1 runtime
+- .NET 6.0 SDK
+- [Linux and MacOS only] Mono 6 (for DocFX)
 
 ## Build system command
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,5 +12,6 @@
         <RepositoryUrl>https://github.com/pleonex/PleOps.Cake</RepositoryUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>netcore;csharp;devops;pipeline;github-actions</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 </Project>

--- a/src/PleOps.Cake/PleOps.Cake.csproj
+++ b/src/PleOps.Cake/PleOps.Cake.csproj
@@ -13,5 +13,6 @@
     <ItemGroup>
         <None Include="*.cake" Pack="true" PackagePath="build" />
         <None Include="../../docs/images/logo_128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
+        <None Include="../../README.md" Pack="true" PackagePath="$(PackageReadmeFile)"/>
     </ItemGroup>
 </Project>

--- a/src/PleOps.Cake/build.cake
+++ b/src/PleOps.Cake/build.cake
@@ -1,5 +1,5 @@
 #load "setup.cake"
-#tool dotnet:?package=ThirdLicense&version=1.1.0
+#tool dotnet:?package=ThirdLicense&version=1.2.0
 
 Task("Build")
     .Description("Build the project")

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.58.4
+#tool nuget:?package=docfx.console&version=2.58.9
 #addin nuget:?package=Cake.DocFx&version=1.0.0
 #addin nuget:?package=Cake.Git&version=1.1.0
 

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,5 +1,5 @@
 #addin nuget:?package=Cake.Git&version=1.1.0
-#tool dotnet:?package=GitVersion.Tool&version=5.7.0
+#tool dotnet:?package=GitVersion.Tool&version=5.8.1
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;


### PR DESCRIPTION
### Description

Update the dependencies so we can run build and release system from the .NET 6 runtime.
Using the new SDK allows also to add the README inside the nuget.

.NET Core 3.1 is not required anymore as ThidLicense runs on .NET 6 now. Mono still required for ReportGenerator and DocFX.