### PR TITLE
Migrate to Cake v2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.3.0",
+      "version": "2.1.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.100'
+  NET_SDK: '6.0.200'
 
 jobs:
   build:

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,8 +1,8 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.58.9
+#tool nuget:?package=docfx.console&version=2.59.0
 #addin nuget:?package=Cake.DocFx&version=1.0.0
-#addin nuget:?package=Cake.Git&version=1.1.0
+#addin nuget:?package=Cake.Git&version=2.0.0
 
 using System.Linq;
 using LibGit2Sharp;

--- a/src/PleOps.Cake/releasenotes.cake
+++ b/src/PleOps.Cake/releasenotes.cake
@@ -1,5 +1,5 @@
 #load "setup.cake"
-#tool "nuget:?package=gitreleasemanager&version=0.12.1"
+#tool "dotnet:?package=GitReleaseManager.Tool&version=0.13.0"
 #addin nuget:?package=Octokit&version=0.50.0
 
 using System.Linq;

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,5 +1,5 @@
-#addin nuget:?package=Cake.Git&version=1.1.0
-#tool dotnet:?package=GitVersion.Tool&version=5.8.1
+#addin nuget:?package=Cake.Git&version=2.0.0
+#tool dotnet:?package=GitVersion.Tool&version=5.8.2
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/src/PleOps.Cake/test.cake
+++ b/src/PleOps.Cake/test.cake
@@ -1,8 +1,6 @@
 #load "setup.cake"
 
-// Cannot upgrade until the following bug is fixed or it won't work on non-Windows
-// https://github.com/cake-build/cake/issues/2216
-#tool nuget:?package=ReportGenerator&version=4.2.15
+#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.0.4
 using System.Globalization;
 
 Task("Test")
@@ -24,7 +22,7 @@ Task("Test")
         DeleteDirectory(testOutput, deleteConfig);
     }
 
-    var netcoreSettings = new DotNetCoreTestSettings {
+    var netcoreSettings = new DotNetTestSettings {
         Configuration = info.Configuration,
         ResultsDirectory = testOutput,
         NoBuild = true,
@@ -40,7 +38,7 @@ Task("Test")
         netcoreSettings.Filter = $"FullyQualifiedName~{info.TestFilter}";
     }
 
-    DotNetCoreTest(info.SolutionFile, netcoreSettings);
+    DotNetTest(info.SolutionFile, netcoreSettings);
 
     // Due to a bug in Azure DevOps we need to delete the *.coverage files.
     // In any case we don't use them, we relay in the Cobertura XML.


### PR DESCRIPTION
### Description

Migrate commands and tools to Cake v2 (2.1).
Thanks to this release, we can finally update `ReportGenerator` to its latest version and run it from Unix.

### Migration steps for users

- Update `dotnet-cake` to `2.1` in _.config/dotnet-tools.json_