### PR TITLE
Replace GitHub token to access release notes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate release notes"
         run: dotnet cake --target=Generate-ReleaseNotes --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: "Build and stage"
         run: dotnet cake --target=Stage-Artifacts --configuration=Release --verbosity=diagnostic
@@ -90,7 +90,7 @@ jobs:
       - name: "Publish artifacts"
         run: dotnet cake --target=Push-Artifacts --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
           PREVIEW_NUGET_FEED_TOKEN: "az"  # Dummy, auth via below env var
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.NUGET_PREVIEW_TOKEN }}"}]}'


### PR DESCRIPTION
### Description

For some reason, the default `GITHUB_TOKEN` is not allowing to access to the content of the release notes. A custom token with no additional permissions, allows it. This PR replaces the variable to access the custom token.

### Migration steps

1. Create a custom token with no additional permissions.
2. Add the token to the secrets repository/organization variables 
3. Replace `secrets.GITHUB_TOKEN` with `secrets.<VAR_NAME>` in _.github/workflows/build-and-release.yml_