### PR TITLE
:umbrella: Test code coverage,  fix dependency for .NET dev container and generate release notes on CI devs builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
         "esbenp.prettier-vscode",
         "yzhang.markdown-all-in-one",
         "davidanson.vscode-markdownlint",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "GitHub.vscode-pull-request-github"
     ],
 
     "remoteUser": "vscode",

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.302'
+  NET_SDK: '6.0.301'
 
 jobs:
   build:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.301'
+  NET_SDK: '6.0.302'
 
 jobs:
   build:

--- a/build.cake
+++ b/build.cake
@@ -5,6 +5,8 @@ Task("Define-Project")
     .Does<BuildInfo>(info =>
 {
     info.AddLibraryProjects("PleOps.Cake");
+    info.AddTestProjects("PleOps.Cake.TestExample");
+
     info.PreviewNuGetFeed = "https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json";
 });
 

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -174,7 +174,7 @@ dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
 
 # Special rules for test projects
-[MyTests/*.cs]
+[PleOps.Cake.TestExample/*.cs]
 dotnet_diagnostic.CS1591.severity = none # Disable documentation
 dotnet_diagnostic.CA1001.severity = none # No need to implement IDisposable in test classes with cleanup.
 dotnet_diagnostic.CA1034.severity = none # Public types in test classes for testing implementations

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,32 +16,4 @@
         <PackageTags>netcore;csharp;devops;pipeline;github-actions</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
-
-    <!-- Deterministic and source link -->
-    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-        <!-- Deterministic and source link -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-
-        <Deterministic>true</Deterministic>
-        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-    </ItemGroup>
-
-    <!-- Code analyzers -->
-    <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All"/>
-        <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="All"/>
-        <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All"/>
-    </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,8 @@
         <Authors>pleonex</Authors>
         <Company>None</Company>
         <Copyright>Copyright (C) 2020 Benito Palacios Sánchez</Copyright>
+
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,4 +16,32 @@
         <PackageTags>netcore;csharp;devops;pipeline;github-actions</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <!-- Deterministic and source link -->
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <!-- Deterministic and source link -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
+        <Deterministic>true</Deterministic>
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <!-- Code analyzers -->
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All"/>
+        <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="All"/>
+        <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All"/>
+    </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,11 +5,5 @@
         <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
         <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-
-        <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.42.0.51121" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="4.1.1" />
     </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+    <!-- Centralize dependency management -->
+    <ItemGroup>
+        <PackageVersion Include="nunit" Version="3.13.3" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
+        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+
+        <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.42.0.51121" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.1.1" />
+    </ItemGroup>
+</Project>

--- a/src/PleOps.Cake.TestExample/DummyTest.cs
+++ b/src/PleOps.Cake.TestExample/DummyTest.cs
@@ -1,0 +1,13 @@
+namespace PleOps.Cake.TestExample;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class DummyTest
+{
+    [Test]
+    public void TestPass()
+    {
+        Assert.Pass();
+    }
+}

--- a/src/PleOps.Cake.TestExample/PleOps.Cake.TestExample.csproj
+++ b/src/PleOps.Cake.TestExample/PleOps.Cake.TestExample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+</Project>

--- a/src/PleOps.Cake.sln
+++ b/src/PleOps.Cake.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PleOps.Cake", "PleOps.Cake/PleOps.Cake.csproj", "{7F6A14F3-6C37-40AE-89F6-720F195FE72B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PleOps.Cake", "PleOps.Cake\PleOps.Cake.csproj", "{7F6A14F3-6C37-40AE-89F6-720F195FE72B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PleOps.Cake.TestExample", "PleOps.Cake.TestExample\PleOps.Cake.TestExample.csproj", "{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +32,17 @@ Global
 		{7F6A14F3-6C37-40AE-89F6-720F195FE72B}.Release|x64.Build.0 = Release|Any CPU
 		{7F6A14F3-6C37-40AE-89F6-720F195FE72B}.Release|x86.ActiveCfg = Release|Any CPU
 		{7F6A14F3-6C37-40AE-89F6-720F195FE72B}.Release|x86.Build.0 = Release|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Debug|x64.Build.0 = Debug|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Debug|x86.Build.0 = Debug|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Release|x64.ActiveCfg = Release|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Release|x64.Build.0 = Release|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Release|x86.ActiveCfg = Release|Any CPU
+		{BD2A6233-1307-4F49-88FB-DD9B796DDEEC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/PleOps.Cake/build.cake
+++ b/src/PleOps.Cake/build.cake
@@ -40,6 +40,8 @@ Task("Pack-Libs")
         // Get changelog and sanitize for XML NuSpec
         changelog = System.IO.File.ReadAllText(info.ChangelogNextFile);
         changelog = System.Security.SecurityElement.Escape(changelog);
+    } else {
+        Information($"Changelog for next version does not exist: {info.ChangelogNextFile}");
     }
 
     var packSettings = new DotNetPackSettings {

--- a/src/PleOps.Cake/releasenotes.cake
+++ b/src/PleOps.Cake/releasenotes.cake
@@ -23,7 +23,6 @@ Task("Create-GitHubDraftRelease")
 
 Task("Export-GitHubReleaseNotes")
     .Description("Export all the release notes from GitHub into a file")
-    .WithCriteria<BuildInfo>((ctxt, info) => info.BuildType != BuildType.Development)
     .WithCriteria<BuildInfo>((ctxt, info) => !string.IsNullOrEmpty(info.GitHubToken))
     .Does<BuildInfo>(info =>
 {

--- a/src/PleOps.Cake/releasenotes.cake
+++ b/src/PleOps.Cake/releasenotes.cake
@@ -28,6 +28,7 @@ Task("Export-GitHubReleaseNotes")
 {
     // Export last milestone to embed in apps and NuGets
     string milestone = info.BuildType switch {
+        BuildType.Development => info.WorkMilestone,
         BuildType.Preview => info.WorkMilestone,
         BuildType.Stable => $"v{info.Version}",
         _ => throw new Exception("Unknown build type for milestone"),

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,5 +1,5 @@
 #addin nuget:?package=Cake.Git&version=2.0.0
-#tool dotnet:?package=GitVersion.Tool&version=5.10.2
+#tool dotnet:?package=GitVersion.Tool&version=5.10.2 // Can't upgrade until Debian 11 provides libc >= 2.33
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,5 +1,7 @@
 #addin nuget:?package=Cake.Git&version=2.0.0
 #tool dotnet:?package=GitVersion.Tool&version=5.10.2 // Can't upgrade until Debian 11 provides libc >= 2.33
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Reflection;
@@ -90,7 +92,7 @@ public class BuildInfo
     {
         foreach (var name in names) {
             string path = System.IO.File.Exists(name) ? name : $"./src/{name}/{name}.csproj";
-            libraries.Add(path);
+            libraries.Add(System.IO.Path.GetFullPath(path));
         }
     }
 
@@ -98,7 +100,7 @@ public class BuildInfo
     {
         foreach (var name in names) {
             string path = System.IO.File.Exists(name) ? name : $"./src/{name}/{name}.csproj";
-            consoles.Add(path);
+            consoles.Add(System.IO.Path.GetFullPath(path));
         }
     }
 
@@ -106,7 +108,7 @@ public class BuildInfo
     {
         foreach (var name in names) {
             string path = System.IO.File.Exists(name) ? name : $"./src/{name}/{name}.csproj";
-            tests.Add(path);
+            tests.Add(System.IO.Path.GetFullPath(path));
         }
     }
 }

--- a/src/PleOps.Cake/targets.cake
+++ b/src/PleOps.Cake/targets.cake
@@ -14,7 +14,7 @@ Task("Generate-ReleaseNotes")
     .IsDependentOn("Define-Project") // Must be defined by the user
     .IsDependentOn("Show-Info")
     .IsDependentOn("Create-GitHubDraftRelease")     // only preview builds
-    .IsDependentOn("Export-GitHubReleaseNotes");    // only preview and stable builds
+    .IsDependentOn("Export-GitHubReleaseNotes");
 
 Task("Stage-Artifacts")
     .IsDependentOn("BuildTest")

--- a/src/PleOps.Cake/test.cake
+++ b/src/PleOps.Cake/test.cake
@@ -1,6 +1,7 @@
 #load "setup.cake"
 
-#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.0.4
+// Can't upgrade until Debian 11 provides libc >= 2.33
+#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.0.3
 using System.Globalization;
 
 Task("Test")


### PR DESCRIPTION
### Description

- Add a dummy .NET test project to test the code coverage dependencies. They were failing in Debian 11 (dev container for .NET 6).
- Downgrade the ReportGenerate dependnecy to be compatible with Debian 11.
- Add useful GitHub extension in the container.
- Generate release notes on PR CI builds so we can detect any related issue.