### PR TITLE
:arrow_up: Upgrade to Cake 3.0 and bump dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.2.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0-jammy
 
 # Install Mono (for DocFX)
 RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
-    && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel
+
+# Bug in the installation of .NET 6 in ubuntu https://github.com/dotnet/runtime/issues/79237
+ENV DOTNET_ROOT=/usr/share/dotnet

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,19 +4,21 @@
         "dockerfile": "Dockerfile",
     },
 
-    "extensions": [
-        "ms-dotnettools.csharp",
-        "k--kato.docomment",
-        "shardulm94.trailing-spaces",
-        "cake-build.cake-vscode",
-        "streetsidesoftware.code-spell-checker",
-        "hediet.vscode-drawio",
-        "esbenp.prettier-vscode",
-        "yzhang.markdown-all-in-one",
-        "davidanson.vscode-markdownlint",
-        "eamodio.gitlens",
-        "GitHub.vscode-pull-request-github"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "shardulm94.trailing-spaces",
+                "cake-build.cake-vscode",
+                "streetsidesoftware.code-spell-checker",
+                "hediet.vscode-drawio",
+                "esbenp.prettier-vscode",
+                "yzhang.markdown-all-in-one",
+                "davidanson.vscode-markdownlint",
+                "eamodio.gitlens"
+            ]
+        }
+    },
 
     "remoteUser": "vscode",
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ The following target are available for build, test and release.
 - `Push-Artifacts`: push the libraries, applications and documentation to the
   preview or stable feed.
 
+## Preview versions
+
+To use a preview version, add a `nuget.config` file in the same directory as
+`build.cake` with the following content:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is only needed if you use preview versions of PleOps.Cake build system -->
+<configuration>
+  <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="PleOps-Preview" value="https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="PleOps-Preview">
+      <package pattern="PleOps.Cake" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+```
+
 ## Documentation
 
 Feel free to ask any question in the

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,8 +2,8 @@
     <!-- Centralize dependency management -->
     <ItemGroup>
         <PackageVersion Include="nunit" Version="3.13.3" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
-        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.4.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     </ItemGroup>
 </Project>

--- a/src/PleOps.Cake/documentation.cake
+++ b/src/PleOps.Cake/documentation.cake
@@ -1,8 +1,8 @@
 #load "setup.cake"
 
-#tool nuget:?package=docfx.console&version=2.59.3
+#tool nuget:?package=docfx.console&version=2.59.4
 #addin nuget:?package=Cake.DocFx&version=1.0.0
-#addin nuget:?package=Cake.Git&version=2.0.0
+#addin nuget:?package=Cake.Git&version=3.0.0
 
 using System.Linq;
 using LibGit2Sharp;

--- a/src/PleOps.Cake/releasenotes.cake
+++ b/src/PleOps.Cake/releasenotes.cake
@@ -1,6 +1,6 @@
 #load "setup.cake"
 #tool "dotnet:?package=GitReleaseManager.Tool&version=0.13.0"
-#addin nuget:?package=Octokit&version=1.0.0
+#addin nuget:?package=Octokit&version=5.0.0
 
 using System.Linq;
 

--- a/src/PleOps.Cake/setup.cake
+++ b/src/PleOps.Cake/setup.cake
@@ -1,5 +1,5 @@
-#addin nuget:?package=Cake.Git&version=2.0.0
-#tool dotnet:?package=GitVersion.Tool&version=5.10.2 // Can't upgrade until Debian 11 provides libc >= 2.33
+#addin nuget:?package=Cake.Git&version=3.0.0
+#tool dotnet:?package=GitVersion.Tool&version=5.12.0
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/PleOps.Cake/test.cake
+++ b/src/PleOps.Cake/test.cake
@@ -1,7 +1,5 @@
 #load "setup.cake"
-
-// Can't upgrade until Debian 11 provides libc >= 2.33
-#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.0.3
+#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.1.18
 using System.Globalization;
 
 Task("Test")


### PR DESCRIPTION
### Description

Test against Cake 3.0 and upgrade all third-parties to their latest version.