### PR TITLE
🐛 Fix exporting release notes with dotnet tools

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -25,6 +25,12 @@
       "commands": [
         "docfx"
       ]
+    },
+    "gitreleasemanager.tool": {
+      "version": "0.14.0",
+      "commands": [
+        "dotnet-gitreleasemanager"
+      ]
     }
   }
 }

--- a/build/orchestrator/Properties/launchSettings.json
+++ b/build/orchestrator/Properties/launchSettings.json
@@ -5,7 +5,10 @@
     },
     "CI-Build": {
       "commandName": "Project",
-      "commandLineArgs": "--target=CI-Build --configuration=Release"
+      "commandLineArgs": "--target=CI-Build --configuration=Release",
+      "environmentVariables": {
+        "GITHUB_REPOSITORY": "pleonex/PleOps.Cake"
+      }
     }
   }
 }

--- a/src/Cake.Frosting.PleOps.Recipe/GitHub/ExportReleaseNotesTask.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/GitHub/ExportReleaseNotesTask.cs
@@ -28,6 +28,7 @@ using Cake.Frosting;
 /// Exports the release notes from the GitHub releases.
 /// </summary>
 [TaskName(nameof(GitHub) + ".ExportReleaseNotes")]
+[IsDependentOn(typeof(Common.RestoreToolsTask))]
 public class ExportReleaseNotesTask : FrostingTask<BuildContext>
 {
     /// <inheritdoc />
@@ -51,6 +52,7 @@ public class ExportReleaseNotesTask : FrostingTask<BuildContext>
                 .AppendFormat(" --repository {0}", context.GitHubContext.RepositoryName)
                 .AppendFormat(" --fileOutputPath \"{0}\"", context.ChangelogNextFile);
 
+            context.Log.Information("Exporting release notes for '{0}'", tagName);
             context.DotNetTool("dotnet-gitreleasemanager " + argBuilder.ToString());
         } catch (Exception ex) {
             context.Log.Warning("Cannot extract latest release notes:\n{0}", ex.ToString());
@@ -65,6 +67,7 @@ public class ExportReleaseNotesTask : FrostingTask<BuildContext>
                 .AppendFormat(" --repository {0}", context.GitHubContext.RepositoryName)
                 .AppendFormat(" --fileOutputPath \"{0}\"", context.ChangelogFile);
 
+            context.Log.Information("Exporting release notes for all versions");
             context.DotNetTool("dotnet-gitreleasemanager " + argBuilder.ToString());
         } catch (Exception ex) {
             context.Log.Warning("Cannot extract release notes:\n{0}", ex.ToString());


### PR DESCRIPTION
### Description

Exporting the release notes from GitHub was failing because GitReleaseManager was not installed. Added as a .NET tool and migrated to run as such.

Related to #66 