### PR TITLE
⬆️ Review and update C# style and coding rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -75,7 +75,7 @@ dotnet_style_prefer_simplified_boolean_expressions = true:warning
 dotnet_style_operator_placement_when_wrapping = end_of_line
 
 ### Null-checking preferences
-dotnet_style_coalesce_expression = true:warning
+dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
@@ -133,6 +133,7 @@ csharp_style_prefer_tuple_swap = true:suggestion
 
 ### 'using' directive preferences
 csharp_using_directive_placement = inside_namespace:warning
+dotnet_diagnostic.SA1200.severity = warning # Doesn't follow above value
 
 ### Modifier preferences
 csharp_prefer_static_local_function = true:warning
@@ -240,6 +241,8 @@ dotnet_diagnostic.IDE0046.severity = suggestion # Simplify ifs
 
 ### StyleCop
 dotnet_diagnostic.SA1000.severity = none # false positive, space before parentheses in new()
+dotnet_diagnostic.SA1009.severity = none # false positive with ()! for null checking
+dotnet_diagnostic.SA1011.severity = none # False positive due to nullables
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
 dotnet_diagnostic.SA1500.severity = none # Allow inline braces
 dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
@@ -264,3 +267,4 @@ dotnet_diagnostic.S1144.severity = none # Remove unused setter
 dotnet_diagnostic.S2094.severity = none # Remove empty class
 dotnet_diagnostic.S2699.severity = none # Assert may be in helper methods
 dotnet_diagnostic.S3966.severity = none # Dispose twice to test implementation
+dotnet_code_quality_unused_parameters = all:none # Some test methods may not use all the source args

--- a/.editorconfig
+++ b/.editorconfig
@@ -51,6 +51,7 @@ dotnet_style_predefined_type_for_member_access = true:warning
 
 ### Modifier preferences
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_diagnostic.SA1400.severity = warning # it doesn't follow the above value
 dotnet_style_readonly_field = true:warning
 
 ### Parentheses preferences
@@ -65,10 +66,10 @@ dotnet_style_collection_initializer = true:warning
 dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_auto_properties = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:warning
 dotnet_style_prefer_conditional_expression_over_return = true:warning
-dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:warning
 dotnet_style_prefer_simplified_boolean_expressions = true:warning
 dotnet_style_operator_placement_when_wrapping = end_of_line
@@ -87,22 +88,23 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 csharp_style_var_for_built_in_types = false:warning
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
+dotnet_diagnostic.IDE0008.severity = suggestion # Doesn't follow above values
 
 ### Expression-bodied members
 csharp_style_expression_bodied_methods = false
 csharp_style_expression_bodied_constructors = false:suggestion
 csharp_style_expression_bodied_operators = true:suggestion
-csharp_style_expression_bodied_properties = when_on_single_line:warning
-csharp_style_expression_bodied_indexers = when_on_single_line:warning
-csharp_style_expression_bodied_accessors = when_on_single_line:warning
-csharp_style_expression_bodied_lambdas = when_on_single_line:warning
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
 csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
 
 ### Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning
-csharp_style_prefer_switch_expression = true:warning
-csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
 csharp_style_prefer_not_pattern = true:warning
 csharp_style_prefer_null_check_over_type_check = true:suggestion
 
@@ -125,6 +127,7 @@ csharp_style_conditional_delegate_call = true:warning
 
 ### Code-block preferences
 csharp_prefer_braces = true:warning
+dotnet_diagnostic.SA1503.severity = warning # Doesn't follow above value
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion
 
@@ -152,40 +155,40 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
 ### Indentation preferences
-csharp_indent_case_contents = true:warning
-csharp_indent_switch_labels = true:warning
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
-csharp_indent_block_contents = true:warning
-csharp_indent_braces = false:warning
-csharp_indent_case_contents_when_block = false:warning
-csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+csharp_style_namespace_declarations = file_scoped
 
 ### Spacing preferences
-csharp_space_after_cast = false:warning
-csharp_space_after_keywords_in_control_flow_statements = true:warning
-csharp_space_between_parentheses = false:warning
-csharp_space_before_colon_in_inheritance_clause = true:warning
-csharp_space_after_colon_in_inheritance_clause = true:warning
-csharp_space_around_binary_operators = before_and_after:warning
-csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
-csharp_space_between_method_declaration_name_and_open_parenthesis = false:warning
-csharp_space_between_method_call_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
-csharp_space_after_comma = true:warning
-csharp_space_before_comma = false:warning
-csharp_space_after_dot = false:warning
-csharp_space_before_dot = false:warning
-csharp_space_after_semicolon_in_for_statement = true:warning
-csharp_space_before_semicolon_in_for_statement = false:warning
-csharp_space_around_declaration_statements = false:warning
-csharp_space_before_open_square_brackets = false:warning
-csharp_space_between_empty_square_brackets = false:warning
-csharp_space_between_square_brackets = false:warning
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
 
 ### Wrapping preferences
-csharp_preserve_single_line_statements = false:warning
+csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
 ### Top level statement
@@ -231,16 +234,18 @@ dotnet_naming_symbols.non_field_members.required_modifiers =
 ## Code analyzers
 ### .NET SDK
 dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log messages from English
+dotnet_diagnostic.SA1025.severity = none # Allow spaces in comments to structure info
 dotnet_diagnostic.IDE0045.severity = suggestion # Simplify ifs
 dotnet_diagnostic.IDE0046.severity = suggestion # Simplify ifs
 
 ### StyleCop
+dotnet_diagnostic.SA1000.severity = none # false positive, space before parentheses in new()
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
 dotnet_diagnostic.SA1500.severity = none # Allow inline braces
-dotnet_diagnostic.SA1503.severity = suggestion # Braces can be omitted (guards can)
 dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 
 ### SonarAnalyzer
+dotnet_diagnostic.S1133.severity = suggestion # Remove deprecated code -.-' I know, some day
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
 
 # Special rules for test projects
@@ -254,5 +259,8 @@ dotnet_diagnostic.CA1305.severity = none # No culture method for quick test code
 dotnet_diagnostic.CA1307.severity = none # No culture method for quick test code
 dotnet_diagnostic.SA0001.severity = none # Disable documentation
 dotnet_diagnostic.SA1600.severity = none # Disable documentation
+dotnet_diagnostic.SA1201.severity = none # Allow enums inside classes
+dotnet_diagnostic.S1144.severity = none # Remove unused setter
+dotnet_diagnostic.S2094.severity = none # Remove empty class
 dotnet_diagnostic.S2699.severity = none # Assert may be in helper methods
 dotnet_diagnostic.S3966.severity = none # Dispose twice to test implementation

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,7 @@ indent_size = 4
 indent_style = space
 tab_width = 8
 trim_trailing_whitespace = true
-end_of_line = crlf# Leave it to git
+end_of_line = unset # Leave it to git
 insert_final_newline = true
 
 ## .NET style rules
@@ -81,7 +81,7 @@ csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 
 ### Expression-bodied members
-csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_methods = false
 csharp_style_expression_bodied_constructors = false:suggestion
 csharp_style_expression_bodied_operators = true:suggestion
 csharp_style_expression_bodied_properties = when_on_single_line:warning
@@ -96,6 +96,7 @@ csharp_style_pattern_matching_over_as_with_null_check = true:warning
 csharp_style_prefer_switch_expression = true:warning
 csharp_style_prefer_pattern_matching = true:warning
 csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_null_check_over_type_check = true:suggestion
 
 ### Expression-level preferences
 csharp_style_inlined_variable_declaration = true:warning
@@ -106,7 +107,9 @@ csharp_style_prefer_index_operator = true:warning
 csharp_style_prefer_range_operator = true:warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:warning
-csharp_style_unused_value_expression_statement_preference = discard_variable:warning
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
 
 ### Null-checking preferences
 csharp_style_throw_expression = true:warning
@@ -115,6 +118,7 @@ csharp_style_conditional_delegate_call = true:warning
 ### Code-block preferences
 csharp_prefer_braces = when_multiline:error
 csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
 
 ### 'using' directive preferences
 csharp_using_directive_placement = inside_namespace:warning
@@ -122,6 +126,12 @@ csharp_using_directive_placement = inside_namespace:warning
 ### Modifier preferences
 csharp_prefer_static_local_function = true:warning
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+
+### New C# features
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
 
 ## C# formatting rules
 ### New line preferences
@@ -132,14 +142,17 @@ csharp_new_line_before_finally = false:warning
 csharp_new_line_before_members_in_object_initializers = true:warning
 csharp_new_line_before_members_in_anonymous_types = true:warning
 csharp_new_line_between_query_expression_clauses = true:warning
+dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
 
 ### Indentation preferences
 csharp_indent_case_contents = true:warning
 csharp_indent_switch_labels = true:warning
-csharp_indent_labels = no_change
+csharp_indent_labels = one_less_than_current
 csharp_indent_block_contents = true:warning
 csharp_indent_braces = false:warning
 csharp_indent_case_contents_when_block = false:warning
+csharp_style_namespace_declarations = file_scoped:suggestion
 
 ### Spacing preferences
 csharp_space_after_cast = false:warning
@@ -169,14 +182,51 @@ csharp_space_between_square_brackets = false:warning
 csharp_preserve_single_line_statements = false:warning
 csharp_preserve_single_line_blocks = true
 
+### Top level statement
+csharp_style_prefer_top_level_statements = true:silent
+
 ## Naming styles rules
+dotnet_style_namespace_match_folder = true:warning
 dotnet_diagnostic.IDE1006.severity = warning
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = warning
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = warning
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+### Symbol specifications
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
 
 ## Code analyzers
 ### .NET SDK
 dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log messages from English
-dotnet_diagnostic.IDE0045.severity= suggestion # Simplify ifs
-dotnet_diagnostic.IDE0046.severity= suggestion # Simplify ifs
+dotnet_diagnostic.IDE0045.severity = suggestion # Simplify ifs
+dotnet_diagnostic.IDE0046.severity = suggestion # Simplify ifs
 
 ### StyleCop
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
@@ -186,13 +236,6 @@ dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 
 ### SonarAnalyzer
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
-csharp_style_namespace_declarations = block_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_prefer_primary_constructors = true:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_style_allow_multiple_blank_lines_experimental = true:silent
-dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
 
 # Special rules for test projects
 [src/Cake.Frosting.PleOps.Samples*/*.cs]
@@ -207,110 +250,3 @@ dotnet_diagnostic.SA0001.severity = none # Disable documentation
 dotnet_diagnostic.SA1600.severity = none # Disable documentation
 dotnet_diagnostic.S2699.severity = none # Assert may be in helper methods
 dotnet_diagnostic.S3966.severity = none # Dispose twice to test implementation
-
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-dotnet_style_coalesce_expression = true:warning
-dotnet_style_null_propagation = true:warning
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
-dotnet_style_prefer_auto_properties = true:warning
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:warning
-dotnet_style_prefer_simplified_boolean_expressions = true:warning
-dotnet_style_prefer_conditional_expression_over_assignment = true:warning
-dotnet_style_prefer_conditional_expression_over_return = true:warning
-dotnet_style_explicit_tuple_names = true:warning
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:warning
-dotnet_style_prefer_simplified_interpolation = true:warning
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_style_operator_placement_when_wrapping = end_of_line
-
-[*.cs]
-csharp_indent_labels = no_change
-csharp_using_directive_placement = inside_namespace:warning
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_prefer_braces = when_multiline:error
-csharp_style_namespace_declarations = file_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_prefer_primary_constructors = true:suggestion
-csharp_style_expression_bodied_methods = when_on_single_line:suggestion
-csharp_style_expression_bodied_constructors = false:suggestion
-csharp_style_expression_bodied_operators = true:suggestion
-csharp_style_expression_bodied_properties = when_on_single_line:warning
-csharp_style_expression_bodied_indexers = when_on_single_line:warning
-csharp_style_expression_bodied_accessors = when_on_single_line:warning
-csharp_style_expression_bodied_lambdas = when_on_single_line:warning
-csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
-csharp_style_throw_expression = true:warning
-csharp_new_line_before_members_in_object_initializers = true
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_prefer_range_operator = true:warning
-csharp_style_prefer_index_operator = true:warning
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_prefer_utf8_string_literals = true:suggestion
-csharp_style_inlined_variable_declaration = true:warning
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:warning
-csharp_style_unused_value_assignment_preference = discard_variable:warning
-csharp_prefer_static_local_function = true:warning
-csharp_style_prefer_readonly_struct = true:suggestion
-csharp_style_prefer_readonly_struct_member = true:suggestion
-csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
-csharp_style_conditional_delegate_call = true:warning
-csharp_style_prefer_switch_expression = true:warning
-csharp_space_around_binary_operators = before_and_after
-csharp_new_line_before_open_brace = types,methods

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,14 @@ root = true
 [*]
 indent_style = space
 
+[*.md]
+charset = utf-8
+insert_final_newline = true
+end_of_line = unset # Leave it to git
+indent_style = space
+indent_size = 2
+max_line_length = 80
+
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
 indent_size = 2
@@ -116,7 +124,7 @@ csharp_style_throw_expression = true:warning
 csharp_style_conditional_delegate_call = true:warning
 
 ### Code-block preferences
-csharp_prefer_braces = when_multiline:error
+csharp_prefer_braces = true:warning
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion
 
@@ -135,15 +143,13 @@ csharp_style_prefer_readonly_struct_member = true:suggestion
 
 ## C# formatting rules
 ### New line preferences
-csharp_new_line_before_open_brace = local_functions,methods,types:warning
-csharp_new_line_before_else = false:warning
-csharp_new_line_before_catch = false:warning
-csharp_new_line_before_finally = false:warning
-csharp_new_line_before_members_in_object_initializers = true:warning
-csharp_new_line_before_members_in_anonymous_types = true:warning
-csharp_new_line_between_query_expression_clauses = true:warning
-dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
-dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+csharp_new_line_before_open_brace = methods,types
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 ### Indentation preferences
 csharp_indent_case_contents = true:warning

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,4 @@
+overrides:
+  - files: "*.md"
+    options:
+      proseWrap: always

--- a/build/orchestrator/Program.cs
+++ b/build/orchestrator/Program.cs
@@ -53,7 +53,6 @@ public sealed class BuildLifetime : FrostingLifetime<BuildContext>
     }
 }
 
-
 [TaskName("Default")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BuildTask))]


### PR DESCRIPTION
### Description

Now we place the `.editorconfig` so it can apply to other languages than .NET (like markdown). This requires a new file `.pretierrc` for some additional settings.

The new C# rules have been reviewed. Existing rules have been adjusted after the feedback of several personal projects.
These rules matches the ones that VS now adds, but be careful opening the file with VS as it does overwrites some of them anyway.

Rules now are more conservative, giving suggestions instead of warnings of errors for shorthands or cool features.

This closes #64 