### PR TITLE
🔼 Migrate to .NET 8.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,19 +15,19 @@
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.26",
+      "version": "5.2.0",
       "commands": [
         "reportgenerator"
       ]
     },
     "docfx": {
-      "version": "2.71.0",
+      "version": "2.73.2",
       "commands": [
         "docfx"
       ]
     },
     "gitreleasemanager.tool": {
-      "version": "0.14.0",
+      "version": "0.16.0",
       "commands": [
         "dotnet-gitreleasemanager"
       ]

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.415'
+  NET_SDK: '8.0.100'
 
 jobs:
   build:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,7 +38,7 @@
         "args": [
           "run",
           "--project",
-          "src/Cake.Frosting.PleOps.Sample.BuildSystem/",
+          "src/Cake.Frosting.PleOps.Samples.BuildSystem/",
         ],
         "group": {
           "kind": "build",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tech stack:
 
 ## Requirements
 
-- .NET 6.0 SDK
+- .NET 8.0 SDK
 
 ## Preview versions
 
@@ -59,7 +59,7 @@ information. For reference, this is the general build and release pipeline.
 
 ## Build
 
-The project requires to build .NET 6.0 SDK.
+The project requires to build .NET 8.0 SDK.
 
 To build, test and generate artifacts run:
 

--- a/build/orchestrator/BuildSystem.csproj
+++ b/build/orchestrator/BuildSystem.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)/../..</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/build/orchestrator/Program.cs
+++ b/build/orchestrator/Program.cs
@@ -39,7 +39,7 @@ public sealed class BuildLifetime : FrostingLifetime<PleOpsBuildContext>
         // Update build parameters from command line arguments.
         context.ReadArguments();
 
-        // HERE you can force values non-overridables.
+        // HERE you can force values non-overridable.
         context.DotNetContext.PreviewNuGetFeed = "https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json";
 
         // Print the build info to use.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,4 @@ pipeline in action!
 
 ## Requirements
 
-- .NET 6.0 SDK
+- .NET 8.0 SDK

--- a/src/Cake.Frosting.PleOps.Recipe/Cake.Frosting.PleOps.Recipe.csproj
+++ b/src/Cake.Frosting.PleOps.Recipe/Cake.Frosting.PleOps.Recipe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,7 +12,7 @@
     <None Include="../../docs/images/logo_128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
     <None Include="../../README.md" Pack="true" PackagePath="$(PackageReadmeFile)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Cake.Frosting" />
   </ItemGroup>

--- a/src/Cake.Frosting.PleOps.Samples.BuildSystem/Cake.Frosting.PleOps.Samples.BuildSystem.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.BuildSystem/Cake.Frosting.PleOps.Samples.BuildSystem.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)/../..</RunWorkingDirectory>

--- a/src/Cake.Frosting.PleOps.Samples.BuildSystem/Program.cs
+++ b/src/Cake.Frosting.PleOps.Samples.BuildSystem/Program.cs
@@ -54,7 +54,7 @@ public sealed class BuildLifetime : FrostingLifetime<MyCustomContext>
         context.DotNetContext.ApplicationProjects.Add(new ProjectPublicationInfo(
             "./src/Cake.Frosting.PleOps.Samples.PublicApp", new[] { "win-x64" }));
         context.DotNetContext.ApplicationProjects.Add(new ProjectPublicationInfo(
-            "./src/Cake.Frosting.PleOps.Samples.PublicApp2", new[] { "linux-x64", "osx-x64" }, "net7.0", "CustomApp"));
+            "./src/Cake.Frosting.PleOps.Samples.PublicApp2", new[] { "linux-x64", "osx-x64" }, "net8.0", "CustomApp"));
         context.ArtifactsPath = "./build/samples_artifacts";
         context.TemporaryPath = "./build/samples_temp";
 

--- a/src/Cake.Frosting.PleOps.Samples.InternalApp/Cake.Frosting.PleOps.Samples.InternalApp.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.InternalApp/Cake.Frosting.PleOps.Samples.InternalApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Cake.Frosting.PleOps.Samples.PublicApp/Cake.Frosting.PleOps.Samples.PublicApp.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.PublicApp/Cake.Frosting.PleOps.Samples.PublicApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SelfContained>false</SelfContained>
 
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Cake.Frosting.PleOps.Samples.PublicApp2/Cake.Frosting.PleOps.Samples.PublicApp2.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.PublicApp2/Cake.Frosting.PleOps.Samples.PublicApp2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>

--- a/src/Cake.Frosting.PleOps.Samples.PublicLibrary/Cake.Frosting.PleOps.Samples.PublicLibrary.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.PublicLibrary/Cake.Frosting.PleOps.Samples.PublicLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/Cake.Frosting.PleOps.Samples.TestLibrary/Cake.Frosting.PleOps.Samples.TestLibrary.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.TestLibrary/Cake.Frosting.PleOps.Samples.TestLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,9 +44,6 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-  </ItemGroup>
 
   <!-- Code analyzers -->
   <PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,17 +1,15 @@
 <Project>
   <!-- Centralize dependency management -->
   <ItemGroup>
-    <PackageVersion Include="Cake.Frosting" Version="3.1.0" />
+    <PackageVersion Include="Cake.Frosting" Version="3.2.0" />
 
-    <PackageVersion Include="nunit" Version="3.13.3" />
+    <PackageVersion Include="nunit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.6.1" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.6.2" />
   </ItemGroup>
 </Project>

--- a/src/DotnetScriptSample/build.csx
+++ b/src/DotnetScriptSample/build.csx
@@ -54,7 +54,7 @@ public sealed class BuildLifetime : FrostingLifetime<MyCustomContext>
         context.DotNetContext.ApplicationProjects.Add(new ProjectPublicationInfo(
             "./src/Cake.Frosting.PleOps.Samples.PublicApp", new[] { "win-x64" }));
         context.DotNetContext.ApplicationProjects.Add(new ProjectPublicationInfo(
-            "./src/Cake.Frosting.PleOps.Samples.PublicApp2", new[] { "linux-x64", "osx-x64" }, "net7.0", "CustomApp"));
+            "./src/Cake.Frosting.PleOps.Samples.PublicApp2", new[] { "linux-x64", "osx-x64" }, "net8.0", "CustomApp"));
         context.ArtifactsPath = "./build/samples_artifacts";
         context.TemporaryPath = "./build/samples_temp";
 


### PR DESCRIPTION
Migrate the Cake recipe library and sample projects to .NET 8.0 LTS.
Also bump Cake to 3.2.0 and related dependencies.
Starting .NET 8, there is no need to reference directly source link as it's enabled by default.

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- The library targets .NET 8.0
- The build agent only needs .NET 8 SDK

### Follow-up work

None

### Example

See CI
