### PR TITLE
🔧 Refactor workflow into reusable files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "thirdlicense": {
-      "version": "1.2.0",
+      "version": "1.3.1",
       "commands": [
         "thirdlicense"
       ]

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,96 +13,24 @@ on:
     types:
       - published
 
-env:
-  NET_SDK: '8.0.100'
-
 jobs:
   build:
     name: "Build"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # We need full history for GitVersion versioning
-
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.NET_SDK }}
-
-      - name: "Build, test and bundle"
-        run: dotnet run --project build/orchestrator -- --target=CI-Build --configuration=Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Test sample build system"
-        run: dotnet run --project src/Cake.Frosting.PleOps.Samples.BuildSystem
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Publish artifacts to CI"
-        uses: actions/upload-artifact@v3
-        with:
-          name: "Artifacts"
-          retention-days: 7
-          path: |
-            build/artifacts/
-            !build/artifacts/docs
-
-      - name: Publish docs artifact to CI
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: build/artifacts/docs
+    uses: ./.github/workflows/build.yml
+    with:
+      dotnet_version: '8.0.100'
 
   # Preview release on push to main only
   # Stable release on version tag push only
   deploy:
     name: "Deploy"
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-    needs: "build"
-    runs-on: ubuntu-latest
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      # Needed only for Azure DevOps Artifacts due to its weird auth method.
-      PREVIEW_NUGET_FEED: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json'
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # We need full history for GitVersion versioning
-
-      - name: "Download artifacts"
-        uses: actions/download-artifact@v3
-        with:
-          name: "Artifacts"
-          path: "./build/artifacts/"
-
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.NET_SDK }}
-
-      # Weird way to authenticate in Azure DevOps Artifacts
-      # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
-      - name: "Install Azure Artifacts Credential Provider"
-        run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
-
-      - name: "Deploy artifacts"
-        run: dotnet run --project build/orchestrator -- --target=CI-Deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
-          PREVIEW_NUGET_FEED_TOKEN: "az"  # Dummy, auth via below env var
-          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.NUGET_PREVIEW_TOKEN }}"}]}'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+    needs: build
+    uses: ./.github/workflows/deploy.yml
+    with:
+      dotnet_version: '8.0.100'
+      azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
+    secrets:
+      #nuget_preview_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}
+      #nuget_stable_token: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
+      azure_nuget_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: "Build"
+
+on:
+  workflow_call:
+    inputs:
+      dotnet_version:
+        required: true
+        type: string
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          # By default they are no "main build" but if it matches "os" then yes.
+          - os: ubuntu-latest
+            is_main_build: true
+    name: "${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # We need full history for version number
+
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: "Build"
+        run: dotnet run --project build/orchestrator -- --target=Default --dotnet-configuration=Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Test with sample build system"
+        run: dotnet run --project src/Cake.Frosting.PleOps.Samples.BuildSystem
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Bundle"
+        if: ${{ matrix.is_main_build }}
+        run: dotnet run --project build/orchestrator -- --target=Bundle --dotnet-configuration=Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Publish artifacts to CI"
+        if: ${{ matrix.is_main_build }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: "Artifacts"
+          retention-days: 7
+          path: |
+            build/artifacts/
+            !build/artifacts/docs
+
+      - name: Publish docs artifact to CI
+        if: ${{ matrix.is_main_build }}
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: build/artifacts/docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: "Deploy"
+
+on:
+  workflow_call:
+    inputs:
+      dotnet_version:
+        required: true
+        type: string
+      azure_nuget_feed:
+        required: false
+        type: string
+    secrets:
+      nuget_preview_token:
+        required: false
+      nuget_stable_token:
+        required: false
+      azure_nuget_token:
+        required: false
+
+jobs:
+  upload_doc:
+    name: "Documentation"
+    runs-on: "ubuntu-latest"
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+
+  push_artifacts:
+    name: "Artifacts"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # We need full history for version number
+
+      - name: "Download artifacts"
+        uses: actions/download-artifact@v3
+        with:
+          name: "Artifacts"
+          path: "./build/artifacts/"
+
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      # Weird way to authenticate in Azure DevOps Artifacts
+      # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
+      - name: "Install Azure Artifacts Credential Provider"
+        run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
+
+      - name: "Deploy artifacts"
+        run: dotnet run --project build/orchestrator -- --target=Deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_NUGET_FEED_TOKEN: ${{ secrets.nuget_stable_token }}
+          PREVIEW_NUGET_FEED_TOKEN: ${{ secrets.nuget_preview_token }}
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ inputs.azure_nuget_feed }}", "username":"", "password":"${{ secrets.azure_nuget_token }}"}]}'

--- a/build/orchestrator/Program.cs
+++ b/build/orchestrator/Program.cs
@@ -55,28 +55,31 @@ public sealed class BuildLifetime : FrostingLifetime<PleOpsBuildContext>
 
 [TaskName("Default")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BuildTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.BuildProjectTask))]
+#if CAKE_ISSUES
+[IsDependentOn(typeof(Cake.Frosting.Issues.Recipe.IssuesTask))]
+#endif
 public sealed class DefaultTask : FrostingTask
 {
 }
 
-[TaskName("CI-Build")]
+[TaskName("Bundle")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.GitHub.ExportReleaseNotesTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.PrepareProjectBundlesTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.DocFxTasks.PrepareProjectBundlesTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.BundleProjectTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BuildTask))]
 #if CAKE_ISSUES
 [IsDependentOn(typeof(Cake.Frosting.Issues.Recipe.IssuesTask))]
 #endif
-public sealed class CIBuildTask : FrostingTask
+public sealed class BundleTask : FrostingTask
 {
 }
 
-[TaskName("CI-Deploy")]
+[TaskName("Deploy")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.DeployProjectTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.GitHub.UploadReleaseBinariesTask))]
-public sealed class CIDeployTask : FrostingTask
+public sealed class DeployTask : FrostingTask
 {
 }

--- a/build/orchestrator/Properties/launchSettings.json
+++ b/build/orchestrator/Properties/launchSettings.json
@@ -3,9 +3,9 @@
     "Default": {
       "commandName": "Project"
     },
-    "CI-Build": {
+    "Bundle": {
       "commandName": "Project",
-      "commandLineArgs": "--target=CI-Build --configuration=Release",
+      "commandLineArgs": "--target=Bundle",
       "environmentVariables": {
         "GITHUB_REPOSITORY": "pleonex/PleOps.Cake"
       }

--- a/src/Cake.Frosting.PleOps.Recipe/DocFx/DocFxTasks.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/DocFx/DocFxTasks.cs
@@ -48,14 +48,4 @@ public static class DocFxTasks
     /// Gets the name of the bundle task.
     /// </summary>
     public const string BundleTaskName = ModuleName + ".Bundle";
-
-    /// <summary>
-    /// Run tasks to build, test and bundle projects.
-    /// </summary>
-    [TaskName(ModuleName + "PrepareProjectBundles")]
-    [IsDependentOn(typeof(BuildTask))]
-    [IsDependentOn(typeof(BundleTask))]
-    public class PrepareProjectBundlesTask : FrostingTask
-    {
-    }
 }

--- a/src/Cake.Frosting.PleOps.Recipe/Dotnet/BundleNuGetsTask.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/Dotnet/BundleNuGetsTask.cs
@@ -29,7 +29,6 @@ using Cake.Frosting;
 /// Task to bundle projects as NuGet packages.
 /// </summary>
 [TaskName(DotnetTasks.BundleNuGetsTaskName)]
-[IsDependentOn(typeof(BuildTask))]
 public class BundleNuGetsTask : FrostingTask<PleOpsBuildContext>
 {
     /// <inheritdoc />

--- a/src/Cake.Frosting.PleOps.Recipe/Dotnet/DotNetBuildContext.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/Dotnet/DotNetBuildContext.cs
@@ -38,7 +38,7 @@ public class DotNetBuildContext
         Platform = "Any CPU";
         ApplicationProjects = new();
 
-        CoverageTarget = 100;
+        CoverageTarget = 80;
         TestFilter = string.Empty;
 
         NugetConfigPath = string.Empty;

--- a/src/Cake.Frosting.PleOps.Recipe/Dotnet/DotnetTasks.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/Dotnet/DotnetTasks.cs
@@ -66,15 +66,23 @@ public static class DotnetTasks
     public const string DeployNuGetTaskName = ModuleName + ".DeployNuGet";
 
     /// <summary>
-    /// Run tasks to build, test and bundle projects.
+    /// Run tasks to build and test projects.
     /// </summary>
-    [TaskName(ModuleName + ".PrepareProjectBundles")]
+    [TaskName(ModuleName + ".BuildProject")]
     [IsDependentOn(typeof(RestoreDependenciesTask))]
     [IsDependentOn(typeof(BuildTask))]
     [IsDependentOn(typeof(TestTask))]
+    public class BuildProjectTask : FrostingTask
+    {
+    }
+
+    /// <summary>
+    /// Run tasks to bundle the deliveries.
+    /// </summary>
+    [TaskName(ModuleName + ".BundleProject")]
     [IsDependentOn(typeof(BundleNuGetsTask))]
     [IsDependentOn(typeof(BundleApplicationsTask))]
-    public class PrepareProjectBundlesTask : FrostingTask
+    public class BundleProjectTask : FrostingTask
     {
     }
 

--- a/src/Cake.Frosting.PleOps.Samples.BuildSystem/Program.cs
+++ b/src/Cake.Frosting.PleOps.Samples.BuildSystem/Program.cs
@@ -83,8 +83,10 @@ public sealed class BuildLifetime : FrostingLifetime<MyCustomContext>
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.GitHub.ExportReleaseNotesTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.PrepareProjectBundlesTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.DocFxTasks.PrepareProjectBundlesTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.BuildProjectTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.BundleProjectTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BuildTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BundleTask))]
 #if CAKE_ISSUES
 [IsDependentOn(typeof(Cake.Frosting.Issues.Recipe.IssuesTask))]
 #endif


### PR DESCRIPTION
Refactor the CI workflow into reusable workflows. The goal is to reduce the size and complexity of the files. It also helps to make them easier to configure via generic variables.

For that I have split the tasks into two steps: "build" (run by every agent) and "bundle" (run only by one agent).

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~ Future
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

This PR closes #65 

## Acceptance criteria

- The build diagram has one block with three items for building in different platform. It doesn't have two separate blocks
- There is one block for deploy (same prod or preview)

### Follow-up work

None

### Example

Check CI output