### PR TITLE
🐛 Small fixes and improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -240,14 +240,9 @@ dotnet_diagnostic.IDE0045.severity = suggestion # Simplify ifs
 dotnet_diagnostic.IDE0046.severity = suggestion # Simplify ifs
 
 ### StyleCop
-dotnet_diagnostic.SA1000.severity = none # false positive, space before parentheses in new()
-dotnet_diagnostic.SA1009.severity = none # false positive with ()! for null checking
-dotnet_diagnostic.SA1011.severity = none # False positive due to nullables
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
 dotnet_diagnostic.SA1204.severity = suggestion # Static methods should be before non-static
-dotnet_diagnostic.SA1313.severity = none # Pascal naming broken with records.
 dotnet_diagnostic.SA1500.severity = none # Allow inline braces
-dotnet_diagnostic.SA1516.severity = none # Multiple blank lines - broken with top-level statements
 dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 
 ### SonarAnalyzer

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at benito356@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <pleonex@protonmail.com>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,87 @@
-# PleOps Cake recipe: a simple DevOps workflow [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://choosealicense.com/licenses/mit/) ![Build and release](https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=main&event=push)
+# PleOps Cake ![logo](./docs/images/logo_48.png)
 
-Full automated build, test, stage and release pipeline for simple .NET projects
-based on Cake. Check also the
-[template repository](https://github.com/pleonex/template-csharp) to see the
-pipeline in action!
+<!-- markdownlint-disable MD033 -->
+<p align="center">
+  <a href="https://www.nuget.org/packages/Cake.Frosting.PleOps.Recipe">
+    <img alt="Stable version" src="https://img.shields.io/nuget/v/Cake.Frosting.PleOps.Recipe?label=nuget.org&logo=nuget" />
+  </a>
+  &nbsp;
+  <a href="https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps">
+    <img alt="GitHub commits since latest release (by SemVer)" src="https://img.shields.io/github/commits-since/pleonex/PleOps.Cake/latest?sort=semver" />
+  </a>
+  &nbsp;
+  <a href="https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release">
+    <img alt="Build and release" src="https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=main&event=push" />
+  </a>
+  &nbsp;
+  <a href="https://choosealicense.com/licenses/mit/">
+    <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat" />
+  </a>
+  &nbsp;
+</p>
 
-Tech stack:
+Complete DevOps workflow and best-practices for .NET projects based on
+[Cake](https://cakebuild.net/).
 
-- Projects: C# / .NET
-- Documentation: DocFX, GitHub page
-- CI: GitHub Actions
-- Release publication: NuGet feeds, GitHub
+- ♻️ DevOps best practices for a software project
+- 🔧 Build, test and release tasks for .NET projects and documentation sites
+- 📚 Documentation explaining the workflow
+- 📋 [Template repository](https://github.com/pleonex/template-csharp) ready to
+  use
 
-<!-- prettier-ignore -->
-| Release | Package                                                           |
-| ------- | ----------------------------------------------------------------- |
-| Stable  | [![Nuget](https://img.shields.io/nuget/v/Cake.Frosting.PleOps.Recipe?label=nuget.org&logo=nuget)](https://www.nuget.org/packages/Cake.Frosting.PleOps.Recipe) |
-| Preview | [Azure Artifacts](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps) |
+## Tech stack
 
-## Requirements
+- **Projects**: C# / .NET
+- **Documentation**: DocFX, GitHub page
+- **CI**: GitHub Actions
+- **Release deployment**: NuGet feeds, GitHub
 
-- .NET 8.0 SDK
+## Get started
 
-## Preview versions
+Check out the [documentation site](https://www.pleonex.dev/PleOps.Cake/) to
+start learning how to use the library.
 
-To use a preview version, add a `nuget.config` file in the repository root
-directory with the following content:
+Feel free to ask any question in the
+[project discussion](https://github.com/pleonex/PleOps.Cake/discussions).
+
+## Usage
+
+The project ships a NuGet library with [Cake Frosting](https://cakebuild.net/)
+tasks:
+
+- `Cake.Frosting.PleOps.Recipe`:
+  ![Package in NuGet](https://img.shields.io/nuget/v/Cake.Frosting.PleOps.Recipe?label=nuget.org&logo=nuget)
+
+To use it, create a new console application with the
+[_Cake Frosting_ template](https://cakebuild.net/docs/getting-started/setting-up-a-new-frosting-project),
+add a reference to this recipe NuGet and its tasks will be available to use.
+
+```cs
+return new CakeHost()
+    .AddAssembly(typeof(Cake.Frosting.PleOps.Recipe.PleOpsBuildContext).Assembly)
+    .UseContext<Cake.Frosting.PleOps.Recipe.PleOpsBuildContext>()
+    .UseLifetime<BuildLifetime>()
+    .Run(args);
+
+[TaskName("Default")]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.BuildProjectTask))]
+public sealed class DefaultTask : FrostingTask
+{
+}
+```
+
+> [!TIP]  
+> Find a detailed setup guide in the
+> [documentation site](<[docs/articles/getting-started/tutorial.md](https://www.pleonex.dev/PleOps.Cake/docs/getting-started/tutorial.html)>).
+
+### Preview releases
+
+Preview releases are in an
+[Azure DevOps NuGet feed](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps).
+Add a `nuget.config` file in the repository root directory with the following
+content:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -47,16 +103,6 @@ directory with the following content:
 </configuration>
 ```
 
-## Documentation
-
-Feel free to ask any question in the
-[project Discussion site!](https://github.com/pleonex/PleOps.Cake/discussions)
-
-Check the [documentation](https://www.pleonex.dev/PleOps.Cake/) for more
-information. For reference, this is the general build and release pipeline.
-
-![release diagram](./docs/articles/workflows/images/release_automation.png)
-
 ## Build
 
 The project requires to build .NET 8.0 SDK.
@@ -64,8 +110,8 @@ The project requires to build .NET 8.0 SDK.
 To build, test and generate artifacts run:
 
 ```sh
-# Build and run tests
-dotnet run --project build/orchestrator -- --target=Default
+# Build and run tests (with code coverage!)
+dotnet run --project build/orchestrator
 
 # (Optional) Create bundles (nuget, zips, docs)
 dotnet run --project build/orchestrator -- --target=Bundle

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ public sealed class DefaultTask : FrostingTask
 
 > [!TIP]  
 > Find a detailed setup guide in the
-> [documentation site](<[docs/articles/getting-started/tutorial.md](https://www.pleonex.dev/PleOps.Cake/docs/getting-started/tutorial.html)>).
+> [documentation site](https://www.pleonex.dev/PleOps.Cake/docs/getting-started/tutorial.html).
 
 ### Preview releases
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,24 @@
-# PleOps Cake
+# PleOps Cake ![logo](./images/logo_48.png)
+
+<!-- markdownlint-disable MD033 -->
+<p align="center">
+  <a href="https://www.nuget.org/packages/Cake.Frosting.PleOps.Recipe">
+    <img alt="Stable version" src="https://img.shields.io/nuget/v/Cake.Frosting.PleOps.Recipe?label=nuget.org&logo=nuget" />
+  </a>
+  &nbsp;
+  <a href="https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps">
+    <img alt="GitHub commits since latest release (by SemVer)" src="https://img.shields.io/github/commits-since/pleonex/PleOps.Cake/latest?sort=semver" />
+  </a>
+  &nbsp;
+  <a href="https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release">
+    <img alt="Build and release" src="https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=main&event=push" />
+  </a>
+  &nbsp;
+  <a href="https://choosealicense.com/licenses/mit/">
+    <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat" />
+  </a>
+  &nbsp;
+</p>
 
 Complete DevOps workflow and best-practices for .NET projects based on
 [Cake](https://cakebuild.net/).
@@ -6,42 +26,55 @@ Complete DevOps workflow and best-practices for .NET projects based on
 - ♻️ DevOps best practices for a software project
 - 🔧 Build, test and release tasks for .NET projects and documentation sites
 - 📚 Documentation explaining the workflow
-- [Template repository](https://github.com/pleonex/template-csharp) ready to use
+- 📋 [Template repository](https://github.com/pleonex/template-csharp) ready to
+  use
 
 ## Tech stack
 
-- Projects: C# / .NET
-- Documentation: DocFX, GitHub page
-- CI: GitHub Actions
-- Release deployment: NuGet feeds, GitHub
+- **Projects**: C# / .NET
+- **Documentation**: DocFX, GitHub page
+- **CI**: GitHub Actions
+- **Release deployment**: NuGet feeds, GitHub
 
 ## Usage
 
 The project ships a NuGet library with [Cake Frosting](https://cakebuild.net/)
-tasks: **`Cake.Frosting.PleOps.Recipe`**.
+tasks:
+
+- `Cake.Frosting.PleOps.Recipe`:
+  ![Package in NuGet](https://img.shields.io/nuget/v/Cake.Frosting.PleOps.Recipe?label=nuget.org&logo=nuget)
 
 To use it, create a new console application with the
 [_Cake Frosting_ template](https://cakebuild.net/docs/getting-started/setting-up-a-new-frosting-project),
 add a reference to this recipe NuGet and its tasks will be available to use.
 
-**More information in the
-[setup guide](./articles/getting-started/tutorial.md).**
+```cs
+return new CakeHost()
+    .AddAssembly(typeof(Cake.Frosting.PleOps.Recipe.PleOpsBuildContext).Assembly)
+    .UseContext<Cake.Frosting.PleOps.Recipe.PleOpsBuildContext>()
+    .UseLifetime<BuildLifetime>()
+    .Run(args);
 
-## Quick demo
-
-You can check this workflow from the
-[template repository](https://github.com/pleonex/template-csharp). Just clone /
-download it and run its build system:
-
-```bash
-# Build and run tests (with code coverage!)
-dotnet run --project build/orchestrator
-
-# Create bundles (nuget, zips, docs)
-dotnet run --project build/orchestrator -- --target=Bundle
+[TaskName("Default")]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.BuildProjectTask))]
+public sealed class DefaultTask : FrostingTask
+{
+}
 ```
 
-Commits will trigger a new continuous integration build with a similar output as
-this:
+Then just run the project to start the build system:
+
+```bash
+dotnet run --project build/orchestrator
+```
+
+Pushing commits will trigger a new continuous integration build with a similar
+output as this:
 
 ![ci-output](./articles/getting-started/images/github-actions-summary.png)
+
+> [!TIP]  
+> Find a detailed setup guide in the
+> [documentation site](articles/getting-started/tutorial.md).

--- a/docs/template/public/main.css
+++ b/docs/template/public/main.css
@@ -1,15 +1,6 @@
 /* Changing the site font */
 @import url("https://fonts.googleapis.com/css2?family=Nunito:wght@100;400;700&display=swap");
-/* @import url('https://fonts.googleapis.com/css2?family=Inconsolata&display=swap'); */
 @import url("https://fonts.googleapis.com/css2?family=Fira Code&display=swap");
-
-/*@import url('https://fonts.cdnfonts.com/css/cascadia-code');*/
-/* @font-face {
-    font-family: 'Cascadia Code';
-    font-style: normal;
-    font-weight: 100;
-    src: local('Cascadia Code'), url('https://fonts.cdnfonts.com/s/29131/Cascadia.woff') format('woff');
-} */
 
 :root {
   --bs-font-sans-serif: "Nunito";

--- a/src/Cake.Frosting.PleOps.Recipe/CakeArgumentsExtensions.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/CakeArgumentsExtensions.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Cake.Frosting.PleOps.Recipe;
+
+using Cake.Core;
+
+/// <summary>
+/// Extension methods for ICakeArguments class.
+/// </summary>
+public static class CakeArgumentsExtensions
+{
+    /// <summary>
+    /// Run the setter if the argument name is present.
+    /// </summary>
+    /// <param name="handler">Cake argument handler.</param>
+    /// <param name="argName">Argument name.</param>
+    /// <param name="setter">Setter to run.</param>
+    public static void SetIfPresent(this ICakeArguments handler, string argName, Action<string> setter)
+    {
+        if (handler.HasArgument(argName)) {
+            setter(handler.GetArgument(argName));
+        }
+    }
+
+    /// <summary>
+    /// Run the setter if the argument name is present.
+    /// </summary>
+    /// <param name="handler">Cake argument handler.</param>
+    /// <param name="argName">Argument name.</param>
+    /// <param name="setter">Setter to run.</param>
+    public static void SetIfPresent(this ICakeArguments handler, string argName, Action<bool> setter)
+    {
+        if (handler.HasArgument(argName)) {
+            string valueText = handler.GetArgument(argName);
+            if (string.IsNullOrEmpty(valueText)) {
+                // If it's present but without value, assume is like a set -> true
+                setter(true);
+            } else {
+                bool value = bool.Parse(handler.GetArgument(argName));
+                setter(value);
+            }
+        }
+    }
+}

--- a/src/Cake.Frosting.PleOps.Recipe/Dotnet/DotNetBuildContext.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/Dotnet/DotNetBuildContext.cs
@@ -146,10 +146,10 @@ public class DotNetBuildContext
             _ => throw new NotSupportedException("Unknown Cake verbosity"),
         };
 
-        context.IfArgIsPresent("dotnet-configuration", x => Configuration = x);
-        context.IfArgIsPresent("dotnet-platform", x => Platform = x);
+        context.Arguments.SetIfPresent("dotnet-configuration", x => Configuration = x);
+        context.Arguments.SetIfPresent("dotnet-platform", x => Platform = x);
 
-        context.IfArgIsPresent("dotnet-test-filter", x => TestFilter = x);
+        context.Arguments.SetIfPresent("dotnet-test-filter", x => TestFilter = x);
 
         PreviewNuGetFeedToken = context.Environment.GetEnvironmentVariable("PREVIEW_NUGET_FEED_TOKEN");
         StableNuGetFeedToken = context.Environment.GetEnvironmentVariable("STABLE_NUGET_FEED_TOKEN");

--- a/src/Cake.Frosting.PleOps.Recipe/PleOpsBuildContext.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/PleOpsBuildContext.cs
@@ -155,29 +155,17 @@ public class PleOpsBuildContext : FrostingContext
 #endif
 
     /// <summary>
-    /// Run the setter if the argument name is present.
-    /// </summary>
-    /// <param name="argName">Argument name.</param>
-    /// <param name="setter">Setter to run.</param>
-    public void IfArgIsPresent(string argName, Action<string> setter)
-    {
-        if (Arguments.HasArgument(argName)) {
-            setter(Arguments.GetArgument(argName));
-        }
-    }
-
-    /// <summary>
     /// Initialize the build context with command-line arguments if present.
     /// </summary>
     public virtual void ReadArguments()
     {
-        IfArgIsPresent("artifacts", x => ArtifactsPath = Path.GetFullPath(x));
-        IfArgIsPresent("temp", x => TemporaryPath = Path.GetFullPath(x));
-        IfArgIsPresent("version", x => Version = x);
-        WarningsAsErrors = WarningsAsErrors || Arguments.HasArgument("warn-as-error");
-        IsIncrementalBuild = IsIncrementalBuild || Arguments.HasArgument("incremental");
-        IfArgIsPresent("changelog-next", x => ChangelogNextFile = x);
-        IfArgIsPresent("changelog", x => ChangelogFile = x);
+        Arguments.SetIfPresent("artifacts", x => ArtifactsPath = Path.GetFullPath(x));
+        Arguments.SetIfPresent("temp", x => TemporaryPath = Path.GetFullPath(x));
+        Arguments.SetIfPresent("version", x => Version = x);
+        Arguments.SetIfPresent("warn-as-error", x => WarningsAsErrors = x);
+        Arguments.SetIfPresent("incremental", x => IsIncrementalBuild = x);
+        Arguments.SetIfPresent("changelog-next", x => ChangelogNextFile = x);
+        Arguments.SetIfPresent("changelog", x => ChangelogFile = x);
 
         DotNetContext.ReadArguments(this);
         DocFxContext.ReadArguments(this);

--- a/src/Cake.Frosting.PleOps.Samples.BuildSystem/Program.cs
+++ b/src/Cake.Frosting.PleOps.Samples.BuildSystem/Program.cs
@@ -20,6 +20,7 @@
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Frosting;
+using Cake.Frosting.PleOps.Recipe;
 using Cake.Frosting.PleOps.Recipe.Dotnet;
 
 return new CakeHost()
@@ -60,7 +61,7 @@ public sealed class BuildLifetime : FrostingLifetime<MyCustomContext>
 
         // Update build parameters from command line arguments.
         context.ReadArguments();
-        context.IfArgIsPresent("custom-setting", x => context.CustomSetting = x);
+        context.Arguments.SetIfPresent("custom-setting", x => context.CustomSetting = x);
 
         // HERE you can force values non-overridables.
         context.DotNetContext.Configuration = "Samples";

--- a/src/Cake.Frosting.PleOps.Samples.PublicApp/Cake.Frosting.PleOps.Samples.PublicApp.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.PublicApp/Cake.Frosting.PleOps.Samples.PublicApp.csproj
@@ -7,8 +7,6 @@
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
 </Project>

--- a/src/Cake.Frosting.PleOps.Samples.PublicApp2/Cake.Frosting.PleOps.Samples.PublicApp2.csproj
+++ b/src/Cake.Frosting.PleOps.Samples.PublicApp2/Cake.Frosting.PleOps.Samples.PublicApp2.csproj
@@ -9,9 +9,6 @@
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <IsPublishable>true</IsPublishable>
   </PropertyGroup>
-
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,12 +7,9 @@
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-    <!-- By default no project generates libs (pack nuget) or apps (publish).
-         Enable one option per project.
-         This allow to publish/pack at the solution level so
-         the platform info is kept. -->
+    <!-- By default no project generates libs (pack nuget). Enable it per project.
+         This allow to pack at the solution level so the platform info is kept. -->
     <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -55,6 +52,5 @@
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All"/>
     <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="All"/>
-    <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,8 +8,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
 
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.6.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Small fixes and improvements:

- Remove `IsPublishable` MSBuild property as it's not used.
- boolean arguments such as `incremental` or `warn-as-error` now accept a custom value to set it to `false` or `true` via CLI
  - Refactor extension method for arguments.
- Upgrade StyleCop to latest beta per author recommendation for latest C# support
- Removed Roslynator analyzer as it gives frequent errors with SDK upgrades.
- Clean-up old comments and markdown warnings

Checklist:
- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- It's possible to assign values to boolean arguments

### Follow-up work

None

### Example

Setting a command-line value for a boolean type: `--incremental=False`
