### PR TITLE
📖 Improve NuGet readme and document doc protection tag

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,9 +9,6 @@ on:
     branches: [ main ]
     # Stable
     tags: [ "v*" ]
-  release:
-    types:
-      - published
 
 jobs:
   build:

--- a/docs/articles/getting-started/tutorial-ci.md
+++ b/docs/articles/getting-started/tutorial-ci.md
@@ -65,3 +65,6 @@ In order to run this workflow you will need to configure a couple of things:
   1. Go to _Settings_ > _Pages_
   2. In _Source_ select _GitHub Actions_
   3. Optionally set a domain and enforce HTTPS.
+  4. Go to _Environments_ and select `github-pages`
+  5. Under _Deployment branches and tags_ add a new rule to allow publishing
+     docs from the tags `v*`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,4 @@
-# PleOps Cake ![logo](./images/logo_48.png)
-
-<!-- markdownlint-disable MD033 -->
-<p align="center">
-  <a href="https://www.nuget.org/packages/Cake.Frosting.PleOps.Recipe">
-    <img alt="Stable version" src="https://img.shields.io/nuget/v/Cake.Frosting.PleOps.Recipe?label=nuget.org&logo=nuget" />
-  </a>
-  &nbsp;
-  <a href="https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps">
-    <img alt="GitHub commits since latest release (by SemVer)" src="https://img.shields.io/github/commits-since/pleonex/PleOps.Cake/latest?sort=semver" />
-  </a>
-  &nbsp;
-  <a href="https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release">
-    <img alt="Build and release" src="https://github.com/pleonex/PleOps.Cake/workflows/Build%20and%20release/badge.svg?branch=main&event=push" />
-  </a>
-  &nbsp;
-  <a href="https://choosealicense.com/licenses/mit/">
-    <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat" />
-  </a>
-  &nbsp;
-</p>
+# PleOps Cake ![MIT license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)
 
 Complete DevOps workflow and best-practices for .NET projects based on
 [Cake](https://cakebuild.net/).

--- a/src/Cake.Frosting.PleOps.Recipe/Cake.Frosting.PleOps.Recipe.csproj
+++ b/src/Cake.Frosting.PleOps.Recipe/Cake.Frosting.PleOps.Recipe.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <None Include="../../docs/images/logo_128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
-    <None Include="../../README.md" Pack="true" PackagePath="$(PackageReadmeFile)" />
+    <None Include="../../docs/index.md" Pack="true" PackagePath="$(PackageReadmeFile)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Small fixes after testing for the first time to deploy NuGets:

- By default GitHub pages are not allowed to publish from tag builds. Documented how to allow it.
- Improve README in NuGets by removing HTML in markdown.
- Removed trigger on release published as it triggers the build twice. We have already the trigger for git tag pushes.

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- README in NuGet does not contain HTML or images
- Document how to publish docs from git tag builds

## Follow-up work

None

## Example

No need.
