### PR TITLE
🐛 Missing dependency to restore GitReleaseManager when uploading binaries

### DIFF
--- a/docs/articles/getting-started/setup-checklist.md
+++ b/docs/articles/getting-started/setup-checklist.md
@@ -85,6 +85,8 @@ following [project template](https://github.com/pleonex/template-csharp).
 4. Review `build.yml` to remove / add OS platforms to run build and tests.
 5. Enable GitHub Pages in the repository settings
    1. Select GitHub Actions as the source.
+   2. From _Environments_, select `github-pages`. Under _Deployment branches and
+      tags_ add a new rule to allow publishing docs from the tags `v*`.
 
 ## Collaboration files
 

--- a/docs/articles/recipe/github.md
+++ b/docs/articles/recipe/github.md
@@ -46,7 +46,7 @@ the current version (if any) into `ChangelogNextFile`.
 - Task name: `PleOps.Recipe.GitHub.UploadReleaseBinaries`
 - Type:
   [`UploadReleaseBinaries`](xref:Cake.Frosting.PleOps.Recipe.GitHub.UploadReleaseBinariesTask)
-- Depends on: none
+- Depends on: [`RestoreTools`](./common.md#restore-tools)
 - Condition: build type is `Stable` and `GitHubToken` is not empty.
 - Build context: `PleOpsBuildContext`
   - Uses:

--- a/src/Cake.Frosting.PleOps.Recipe/GitHub/UploadReleaseBinariesTask.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/GitHub/UploadReleaseBinariesTask.cs
@@ -30,6 +30,7 @@ using Cake.Frosting;
 /// This action only runs for stable builds if the GitHub token is present.
 /// </remarks>
 [TaskName("PleOps.Recipe.GitHub.UploadReleaseBinaries")]
+[IsDependentOn(typeof(Common.RestoreToolsTask))]
 public class UploadReleaseBinariesTask : FrostingTask<PleOpsBuildContext>
 {
     /// <inheritdoc />


### PR DESCRIPTION
`UploadReleaseBinariesTask` was missing a dependency task with `RestoreTools` to download _GitReleaseManager_. This may cause the pipeline to fail on release.

Also document steps to publish docs from tags in checklist.

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- GitReleaseManager is restored automatically upon running UploadReleaseBinariesTask

## Follow-up work

- Update template-csharp and re-release

## Example

None
