### PR TITLE
📚 Add missing steps to setup GitHub Pages and other small doc fixes

### DIFF
--- a/docs/articles/getting-started/setup-checklist.md
+++ b/docs/articles/getting-started/setup-checklist.md
@@ -87,6 +87,9 @@ following [project template](https://github.com/pleonex/template-csharp).
    1. Select GitHub Actions as the source.
    2. From _Environments_, select `github-pages`. Under _Deployment branches and
       tags_ add a new rule to allow publishing docs from the tags `v*`.
+   3. Enable write permissions to publish GitHub Pages. From Actions, "General",
+      go to "Workflow permissions" and ensure it's set to "Read and write
+      permissions".
 
 ## Collaboration files
 
@@ -99,7 +102,9 @@ following [project template](https://github.com/pleonex/template-csharp).
       explain how to create issues and pull requests.
    2. `CODE_OF_CONDUCT.md`: GitHub can help to create it.
 3. Create IDE support files:
-   1. [`.editorconfig`](https://github.com/pleonex/template-csharp/blob/main/.editorconfig):
+   1. [`.editorconfig`](https://github.com/pleonex/template-csharp/blob/main/.editorconfig)
+      and
+      [`.prettierrc.yaml`](https://github.com/pleonex/template-csharp/blob/main/.prettierrc.yaml):
       code styles and code warnings.
    2. [`.vscode/`](https://github.com/pleonex/template-csharp/tree/main/.vscode):
       VS Code support to build, run and debug the project.

--- a/docs/articles/getting-started/setup-template.md
+++ b/docs/articles/getting-started/setup-template.md
@@ -13,7 +13,7 @@ structure. Then follow this checklist to adapt the template to your project.
 
 1. Rename, edit, remove the project folders inside `src/` and the solution file.
 2. Edit the project name and URL in `src/Directory.Build.props`
-3. Add, remove, update dependencies in `src/Directory.Build.targets`
+3. Add, remove, update dependencies in `src/Directory.Packages.props`
 4. Update the `.csproj` files with the correct dependencies.
 5. Update `build/orchestrator/Program.cs` with the list of publishable .NET
    projects in `ApplicationProjects`.
@@ -37,7 +37,9 @@ structure. Then follow this checklist to adapt the template to your project.
    `nuget_preview_token` or `azure_nuget_token`
 3. Review `build.yml` to remove / add OS platforms to run build and tests.
 4. Enable GitHub Pages in the repository settings
-   1. Select GitHub Actions as the source.
+   1. Pages -> Select GitHub Actions as the source.
+   2. Environments -> github-pages -> Add new rule for tags `v*`
+   3. Actions -> General -> Workflow permissions -> Read and write permissions
 
 ## Collaboration files
 

--- a/docs/articles/getting-started/tutorial-ci.md
+++ b/docs/articles/getting-started/tutorial-ci.md
@@ -62,9 +62,14 @@ In order to run this workflow you will need to configure a couple of things:
     and pass it to `azure_nuget_token` input. Define also `azure_nuget_feed`.
 - **Enable GitHub pages**: if you want to publish your documentation via GitHub
   pages, you need to enable in your project settings:
-  1. Go to _Settings_ > _Pages_
-  2. In _Source_ select _GitHub Actions_
-  3. Optionally set a domain and enforce HTTPS.
-  4. Go to _Environments_ and select `github-pages`
-  5. Under _Deployment branches and tags_ add a new rule to allow publishing
-     docs from the tags `v*`.
+  - Enable publishing from a GitHub Action:
+    1. Go to _Settings_ > _Pages_
+    2. In _Source_ select _GitHub Actions_
+    3. Optionally set a domain and enforce HTTPS.
+  - Allow to publish documentation from a tag (release builds):
+    1. Go to _Environments_ and select `github-pages`
+    2. Under _Deployment branches and tags_ add a new rule to allow publishing
+       docs from the tags `v*`.
+  - Give write permissions to `GITHUB_TOKEN`:
+    1. Go to _Actions_ > _General_
+    2. Under _Workflow permissions_ select _Read and write permissions_.


### PR DESCRIPTION
- Add missing steps to setup properly GitHub Pages:
  - Write permissions for GitHub Token not enabled by default on new repos
  - Allow publishing docs from git tags
- Add missing reference to `.prettierrc`
- Typo in `Directory.packages.props` 

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- Document steps tested on a new repo allowing to publish docs

## Follow-up work

None