### PR TITLE
:bug: Do not fail uploading binaries to the GitHub release if there are none

### DIFF
--- a/docs/articles/recipe/github.md
+++ b/docs/articles/recipe/github.md
@@ -59,3 +59,6 @@ the current version (if any) into `ChangelogNextFile`.
 
 Upload the release artifact binaries into the GitHub release that matches the
 current version.
+
+The task will not fail if there are no binaries. It will just log a message and
+do nothing.

--- a/src/Cake.Frosting.PleOps.Recipe/GitHub/UploadReleaseBinariesTask.cs
+++ b/src/Cake.Frosting.PleOps.Recipe/GitHub/UploadReleaseBinariesTask.cs
@@ -43,6 +43,11 @@ public class UploadReleaseBinariesTask : FrostingTask<PleOpsBuildContext>
     /// <inheritdoc />
     public override void Run(PleOpsBuildContext context)
     {
+        if (context.DeliveriesContext.BinaryFiles.Count == 0) {
+            context.Log.Information("No binaries to upload found.");
+            return;
+        }
+
         string tagName = $"v{context.Version}";
         string artifacts = string.Join(
             ",",


### PR DESCRIPTION
To prevent build failures, do nothing if there are no binaries to upload to GitHub.
We could argue that by failing we detect when they are not uploaded, and if there aren't any we should remove the task. But it comes the template, it could be easily forgotten and get a build failure at release time.

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- The build does not fail in the GitHub upload binary if there are no binaries

## Follow-up work

None

## Example
N/A